### PR TITLE
UF-4270: Renamed status value from CERTIFIED to APPROVED

### DIFF
--- a/src/integration-test/resources/BillingRecordIT/__files/test02_readBillingRecordById/response.json
+++ b/src/integration-test/resources/BillingRecordIT/__files/test02_readBillingRecordById/response.json
@@ -2,9 +2,9 @@
 	"id": "1310ee8b-ecf9-4fe1-ab9d-f19153b19d06",
 	"category": "ACCESS_CARD",
 	"type": "INTERNAL",
-	"status": "CERTIFIED",
-	"certifiedBy": "JOE01DOE",
-	"certified": "2022-06-30T08:52:25.112+02:00",
+	"status": "APPROVED",
+	"approvedBy": "JOE01DOE",
+	"approved": "2022-06-30T08:52:25.112+02:00",
 	"invoice": {
 		"customerId": "15",
 		"description": "Passerkort med foto för Ivan Drago (IVA02DRA)",

--- a/src/integration-test/resources/BillingRecordIT/__files/test03_readAllBillingRecords/response.json
+++ b/src/integration-test/resources/BillingRecordIT/__files/test03_readAllBillingRecords/response.json
@@ -4,9 +4,9 @@
 			"id": "1310ee8b-ecf9-4fe1-ab9d-f19153b19d06",
 			"category": "ACCESS_CARD",
 			"type": "INTERNAL",
-			"status": "CERTIFIED",
-			"certifiedBy": "JOE01DOE",
-			"certified": "2022-06-30T08:52:25.112+02:00",
+			"status": "APPROVED",
+			"approvedBy": "JOE01DOE",
+			"approved": "2022-06-30T08:52:25.112+02:00",
 			"invoice": {
 				"customerId": "15",
 				"description": "Passerkort med foto för Ivan Drago (IVA02DRA)",

--- a/src/main/java/se/sundsvall/billingpreprocessor/api/model/BillingRecord.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/api/model/BillingRecord.java
@@ -18,13 +18,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import se.sundsvall.billingpreprocessor.api.model.enums.Status;
 import se.sundsvall.billingpreprocessor.api.model.enums.Type;
 import se.sundsvall.billingpreprocessor.api.validation.ValidAddressDetails;
-import se.sundsvall.billingpreprocessor.api.validation.ValidCertifiedBy;
+import se.sundsvall.billingpreprocessor.api.validation.ValidApprovedBy;
 import se.sundsvall.billingpreprocessor.api.validation.ValidInvoice;
 import se.sundsvall.billingpreprocessor.api.validation.ValidInvoiceRows;
 import se.sundsvall.billingpreprocessor.api.validation.ValidIssuer;
 
 @Schema(description = "Billing record model")
-@ValidCertifiedBy
+@ValidApprovedBy
 @ValidInvoice
 @ValidInvoiceRows
 @ValidIssuer
@@ -48,13 +48,13 @@ public class BillingRecord {
 	@NotNull
 	private Status status;
 
-	@Schema(description = "Information regarding the person that has certificed the billing record", example = "Big Bird")
-	private String certifiedBy;
+	@Schema(description = "Information regarding the person that has approved the billing record", example = "Big Bird")
+	private String approvedBy;
 
-	@Schema(description = "Timestamp when the billing record got certified status", example = "2022-11-21T16:57:13.988+02:00", accessMode = READ_ONLY)
+	@Schema(description = "Timestamp when the billing record got approved status", example = "2022-11-21T16:57:13.988+02:00", accessMode = READ_ONLY)
 	@DateTimeFormat(iso = ISO.DATE_TIME)
 	@Null
-	private OffsetDateTime certified;
+	private OffsetDateTime approved;
 
 	@Schema(implementation = Issuer.class)
 	@Valid
@@ -131,29 +131,29 @@ public class BillingRecord {
 		return this;
 	}
 
-	public String getCertifiedBy() {
-		return certifiedBy;
+	public String getApprovedBy() {
+		return approvedBy;
 	}
 
-	public void setCertifiedBy(String certifiedBy) {
-		this.certifiedBy = certifiedBy;
+	public void setApprovedBy(String approvedBy) {
+		this.approvedBy = approvedBy;
 	}
 
-	public BillingRecord withCertifiedBy(String certifiedBy) {
-		this.certifiedBy = certifiedBy;
+	public BillingRecord withApprovedBy(String approvedBy) {
+		this.approvedBy = approvedBy;
 		return this;
 	}
 
-	public OffsetDateTime getCertified() {
-		return certified;
+	public OffsetDateTime getApproved() {
+		return approved;
 	}
 
-	public void setCertified(OffsetDateTime certified) {
-		this.certified = certified;
+	public void setApproved(OffsetDateTime approved) {
+		this.approved = approved;
 	}
 
-	public BillingRecord withCertified(OffsetDateTime certified) {
-		this.certified = certified;
+	public BillingRecord withApproved(OffsetDateTime approved) {
+		this.approved = approved;
 		return this;
 	}
 
@@ -211,7 +211,7 @@ public class BillingRecord {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(category, certified, certifiedBy, created, id, invoice, issuer, modified, status, type);
+		return Objects.hash(category, approved, approvedBy, created, id, invoice, issuer, modified, status, type);
 	}
 
 	@Override
@@ -226,7 +226,7 @@ public class BillingRecord {
 			return false;
 		}
 		BillingRecord other = (BillingRecord) obj;
-		return category == other.category && Objects.equals(certified, other.certified) && Objects.equals(certifiedBy, other.certifiedBy) && Objects.equals(created, other.created) && Objects.equals(id, other.id) && Objects.equals(invoice,
+		return category == other.category && Objects.equals(approved, other.approved) && Objects.equals(approvedBy, other.approvedBy) && Objects.equals(created, other.created) && Objects.equals(id, other.id) && Objects.equals(invoice,
 			other.invoice) && Objects.equals(issuer, other.issuer) && Objects.equals(modified, other.modified) && status == other.status && type == other.type;
 	}
 
@@ -237,8 +237,8 @@ public class BillingRecord {
 			.append(", category=").append(category)
 			.append(", type=").append(type)
 			.append(", status=").append(status)
-			.append(", certifiedBy=").append(certifiedBy)
-			.append(", certified=").append(certified)
+			.append(", approvedBy=").append(approvedBy)
+			.append(", approved=").append(approved)
 			.append(", issuer=").append(issuer)
 			.append(", invoice=").append(invoice)
 			.append(", created=").append(created)

--- a/src/main/java/se/sundsvall/billingpreprocessor/api/model/enums/Status.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/api/model/enums/Status.java
@@ -2,10 +2,10 @@ package se.sundsvall.billingpreprocessor.api.model.enums;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(description = "Billing status model", enumAsRef = true, example = "CERTIFIED")
+@Schema(description = "Billing status model", enumAsRef = true, example = "APPROVED")
 public enum Status {
 	NEW,
-	CERTIFIED,
+	APPROVED,
 	INVOICED,
 	REJECTED;
 }

--- a/src/main/java/se/sundsvall/billingpreprocessor/api/validation/ValidApprovedBy.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/api/validation/ValidApprovedBy.java
@@ -9,13 +9,13 @@ import java.lang.annotation.Target;
 import javax.validation.Constraint;
 import javax.validation.Payload;
 
-import se.sundsvall.billingpreprocessor.api.validation.impl.ValidCertifiedByConstraintValidator;
+import se.sundsvall.billingpreprocessor.api.validation.impl.ValidApprovedByConstraintValidator;
 
 @Documented
 @Target({ ElementType.FIELD, ElementType.CONSTRUCTOR, ElementType.PARAMETER, ElementType.TYPE_USE })
 @Retention(RetentionPolicy.RUNTIME)
-@Constraint(validatedBy = ValidCertifiedByConstraintValidator.class)
-public @interface ValidCertifiedBy {
+@Constraint(validatedBy = ValidApprovedByConstraintValidator.class)
+public @interface ValidApprovedBy {
 	String message() default "can not be blank";
 
 	Class<?>[] groups() default {};

--- a/src/main/java/se/sundsvall/billingpreprocessor/api/validation/impl/ValidApprovedByConstraintValidator.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/api/validation/impl/ValidApprovedByConstraintValidator.java
@@ -1,20 +1,20 @@
 package se.sundsvall.billingpreprocessor.api.validation.impl;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static se.sundsvall.billingpreprocessor.api.model.enums.Status.CERTIFIED;
+import static se.sundsvall.billingpreprocessor.api.model.enums.Status.APPROVED;
 
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 
 import se.sundsvall.billingpreprocessor.api.model.BillingRecord;
-import se.sundsvall.billingpreprocessor.api.validation.ValidCertifiedBy;
+import se.sundsvall.billingpreprocessor.api.validation.ValidApprovedBy;
 
-public class ValidCertifiedByConstraintValidator implements ConstraintValidator<ValidCertifiedBy, BillingRecord> {
-	private static final String CUSTOM_ERROR_MESSAGE = "certifiedBy must be present when status is " + CERTIFIED;
+public class ValidApprovedByConstraintValidator implements ConstraintValidator<ValidApprovedBy, BillingRecord> {
+	private static final String CUSTOM_ERROR_MESSAGE = "approvedBy must be present when status is " + APPROVED;
 
 	@Override
 	public boolean isValid(final BillingRecord billingRecord, final ConstraintValidatorContext context) {
-		final var isValid = billingRecord.getStatus() != CERTIFIED || isNotBlank(billingRecord.getCertifiedBy());
+		final var isValid = billingRecord.getStatus() != APPROVED || isNotBlank(billingRecord.getApprovedBy());
 
 		if (!isValid) {
 			useCustomMessageForValidation(context);

--- a/src/main/java/se/sundsvall/billingpreprocessor/integration/db/model/BillingRecordEntity.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/integration/db/model/BillingRecordEntity.java
@@ -50,11 +50,11 @@ public class BillingRecordEntity implements Serializable {
 	@Enumerated(STRING)
 	private Status status;
 
-	@Column(name = "certified_by")
-	private String certifiedBy;
+	@Column(name = "approved_by")
+	private String approvedBy;
 
-	@Column(name = "certified")
-	private OffsetDateTime certified;
+	@Column(name = "approved")
+	private OffsetDateTime approved;
 
 	@Column(name = "created")
 	private OffsetDateTime created;
@@ -134,29 +134,29 @@ public class BillingRecordEntity implements Serializable {
 		return this;
 	}
 
-	public String getCertifiedBy() {
-		return certifiedBy;
+	public String getApprovedBy() {
+		return approvedBy;
 	}
 
-	public void setCertifiedBy(String certifiedBy) {
-		this.certifiedBy = certifiedBy;
+	public void setApprovedBy(String approvedBy) {
+		this.approvedBy = approvedBy;
 	}
 
-	public BillingRecordEntity withCertifiedBy(String certifiedBy) {
-		this.certifiedBy = certifiedBy;
+	public BillingRecordEntity withApprovedBy(String approvedBy) {
+		this.approvedBy = approvedBy;
 		return this;
 	}
 
-	public OffsetDateTime getCertified() {
-		return certified;
+	public OffsetDateTime getApproved() {
+		return approved;
 	}
 
-	public void setCertified(OffsetDateTime certified) {
-		this.certified = certified;
+	public void setApproved(OffsetDateTime approved) {
+		this.approved = approved;
 	}
 
-	public BillingRecordEntity withCertified(OffsetDateTime certified) {
-		this.certified = certified;
+	public BillingRecordEntity withApproved(OffsetDateTime approved) {
+		this.approved = approved;
 		return this;
 	}
 
@@ -214,7 +214,7 @@ public class BillingRecordEntity implements Serializable {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(category, certified, certifiedBy, created, id, invoice, issuer, modified, status, type);
+		return Objects.hash(category, approved, approvedBy, created, id, invoice, issuer, modified, status, type);
 	}
 
 	@Override
@@ -229,7 +229,7 @@ public class BillingRecordEntity implements Serializable {
 			return false;
 		}
 		BillingRecordEntity other = (BillingRecordEntity) obj;
-		return Objects.equals(category, other.category) && Objects.equals(certified, other.certified) && Objects.equals(certifiedBy, other.certifiedBy) && Objects.equals(created, other.created) && Objects.equals(id, other.id) && Objects.equals(
+		return Objects.equals(category, other.category) && Objects.equals(approved, other.approved) && Objects.equals(approvedBy, other.approvedBy) && Objects.equals(created, other.created) && Objects.equals(id, other.id) && Objects.equals(
 			invoice, other.invoice) && Objects.equals(issuer, other.issuer) && Objects.equals(modified, other.modified) && Objects.equals(status, other.status) && Objects.equals(type, other.type);
 	}
 
@@ -240,8 +240,8 @@ public class BillingRecordEntity implements Serializable {
 			.append(", category=").append(category)
 			.append(", type=").append(type)
 			.append(", status=").append(status)
-			.append(", certifiedBy=").append(certifiedBy)
-			.append(", certified=").append(certified)
+			.append(", approvedBy=").append(approvedBy)
+			.append(", approved=").append(approved)
 			.append(", created=").append(created)
 			.append(", modified=").append(modified)
 			.append(", issuer=").append(issuer)

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/mapper/BillingRecordMapper.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/mapper/BillingRecordMapper.java
@@ -9,7 +9,7 @@ import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
 import static org.springframework.util.ObjectUtils.isEmpty;
-import static se.sundsvall.billingpreprocessor.api.model.enums.Status.CERTIFIED;
+import static se.sundsvall.billingpreprocessor.api.model.enums.Status.APPROVED;
 import static se.sundsvall.billingpreprocessor.integration.db.model.DescriptionType.DETAILED;
 import static se.sundsvall.billingpreprocessor.integration.db.model.DescriptionType.STANDARD;
 import static se.sundsvall.billingpreprocessor.service.util.CalculationUtil.calculateTotalInvoiceAmount;
@@ -51,8 +51,8 @@ public class BillingRecordMapper {
 		billingRecordEntity.setIssuer(toIssuerEntity(billingRecordEntity, billingRecord.getIssuer())); // Add issuer entity to billing record entity
 		billingRecordEntity.setInvoice(toInvoiceEntity(billingRecordEntity, billingRecord.getInvoice())); // Add invoice entity to billing record entity
 
-		if (CERTIFIED == billingRecordEntity.getStatus()) {
-			setCertifiedBy(billingRecordEntity, billingRecord.getCertifiedBy());
+		if (APPROVED == billingRecordEntity.getStatus()) {
+			setApprovedBy(billingRecordEntity, billingRecord.getApprovedBy());
 		}
 
 		return billingRecordEntity;
@@ -74,21 +74,20 @@ public class BillingRecordMapper {
 		billingRecordEntity.setIssuer(toIssuerEntity(billingRecordEntity, billingRecord.getIssuer())); // Update issuer entity of billing record entity with new information
 		billingRecordEntity.setInvoice(toInvoiceEntity(billingRecordEntity, billingRecord.getInvoice())); // Update invoice entity of billing record entity with new information
 
-		// Only set certified by and certified timestamp first time billing record receives certified status
-		if (CERTIFIED == billingRecordEntity.getStatus() && isNull(billingRecordEntity.getCertified())) {
-			setCertifiedBy(billingRecordEntity, billingRecord.getCertifiedBy());
+		// Only set approved by and approved timestamp first time billing record receives approved status
+		if (APPROVED == billingRecordEntity.getStatus() && isNull(billingRecordEntity.getApproved())) {
+			setApprovedBy(billingRecordEntity, billingRecord.getApprovedBy());
 		}
 
 		// Need to trigger modified date for billing record manually here as adding or modifying sub entities doesn't trigger
-		// the
-		// @preUpdate annotation
+		// the @preUpdate annotation
 		return billingRecordEntity.withModified(now().truncatedTo(MILLIS));
 	}
 
-	private static void setCertifiedBy(final BillingRecordEntity billingRecordEntity, String certifiedBy) {
+	private static void setApprovedBy(final BillingRecordEntity billingRecordEntity, String approvedBy) {
 		billingRecordEntity
-			.withCertified(now())
-			.withCertifiedBy(certifiedBy);
+			.withApproved(now())
+			.withApprovedBy(approvedBy);
 	}
 
 	private static InvoiceEntity toInvoiceEntity(final BillingRecordEntity billingRecordEntity, final Invoice invoice) {
@@ -191,8 +190,8 @@ public class BillingRecordMapper {
 	public static BillingRecord toBillingRecord(final BillingRecordEntity billingRecordEntity) {
 		return BillingRecord.create()
 			.withCategory(billingRecordEntity.getCategory())
-			.withCertified(billingRecordEntity.getCertified())
-			.withCertifiedBy(billingRecordEntity.getCertifiedBy())
+			.withApproved(billingRecordEntity.getApproved())
+			.withApprovedBy(billingRecordEntity.getApprovedBy())
 			.withCreated(billingRecordEntity.getCreated())
 			.withId(billingRecordEntity.getId())
 			.withInvoice(toInvoice(billingRecordEntity.getInvoice()))

--- a/src/main/resources/db/migration/V1_2__rename_certified_columns_to_approved_in_billingrecord_table.sql
+++ b/src/main/resources/db/migration/V1_2__rename_certified_columns_to_approved_in_billingrecord_table.sql
@@ -1,0 +1,6 @@
+
+    alter table billing_record 
+    change column certified approved datetime(6);
+    
+    alter table billing_record
+    change column certified_by approved_by varchar(255);

--- a/src/test/java/se/sundsvall/billingpreprocessor/api/BillingRecordRequestUtil.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/api/BillingRecordRequestUtil.java
@@ -1,5 +1,13 @@
 package se.sundsvall.billingpreprocessor.api;
 
+import static java.time.OffsetDateTime.now;
+import static java.util.UUID.randomUUID;
+import static se.sundsvall.billingpreprocessor.api.model.enums.Status.APPROVED;
+import static se.sundsvall.billingpreprocessor.api.model.enums.Type.EXTERNAL;
+import static se.sundsvall.billingpreprocessor.api.model.enums.Type.INTERNAL;
+
+import java.util.List;
+
 import se.sundsvall.billingpreprocessor.api.model.AccountInformation;
 import se.sundsvall.billingpreprocessor.api.model.AddressDetails;
 import se.sundsvall.billingpreprocessor.api.model.BillingRecord;
@@ -8,14 +16,6 @@ import se.sundsvall.billingpreprocessor.api.model.InvoiceRow;
 import se.sundsvall.billingpreprocessor.api.model.Issuer;
 import se.sundsvall.billingpreprocessor.api.model.enums.Type;
 
-import java.util.List;
-
-import static java.time.OffsetDateTime.now;
-import static java.util.UUID.randomUUID;
-import static se.sundsvall.billingpreprocessor.api.model.enums.Status.CERTIFIED;
-import static se.sundsvall.billingpreprocessor.api.model.enums.Type.EXTERNAL;
-import static se.sundsvall.billingpreprocessor.api.model.enums.Type.INTERNAL;
-
 public class BillingRecordRequestUtil {
 
 	private BillingRecordRequestUtil() {
@@ -23,58 +23,58 @@ public class BillingRecordRequestUtil {
 
 	public static BillingRecord createBillingRecordInstance(Type type, boolean validBillingRecord) {
 		return BillingRecord.create()
-				.withCategory(validBillingRecord ? "ACCESS_CARD" : "INVALID")
-				.withCertified(validBillingRecord ? null : now())
-				.withCertifiedBy("certifiedBy")
-				.withCreated(validBillingRecord ? null : now())
-				.withId(validBillingRecord ? null : randomUUID().toString())
-				.withModified(validBillingRecord ? null : now())
-				.withStatus(CERTIFIED)
-				.withType(type);
+			.withCategory(validBillingRecord ? "ACCESS_CARD" : "INVALID")
+			.withApproved(validBillingRecord ? null : now())
+			.withApprovedBy("approvedBy")
+			.withCreated(validBillingRecord ? null : now())
+			.withId(validBillingRecord ? null : randomUUID().toString())
+			.withModified(validBillingRecord ? null : now())
+			.withStatus(APPROVED)
+			.withType(type);
 	}
 
 	public static Issuer createIssuerInstance(boolean validIssuer) {
 		return Issuer.create()
-				.withFirstName(validIssuer ? "firstName" : null)
-				.withPartyId(randomUUID().toString())
-				.withLastName("lastName")
-				.withUserId("userId");
+			.withFirstName(validIssuer ? "firstName" : null)
+			.withPartyId(randomUUID().toString())
+			.withLastName("lastName")
+			.withUserId("userId");
 	}
 
 	public static AddressDetails createAddressDetailsInstance(boolean validAddress) {
 		return validAddress ? AddressDetails.create()
-				.withCareOf("careOf")
-				.withCity("city")
-				.withStreet("street")
-				.withtPostalCode("zipCode") : AddressDetails.create();
+			.withCareOf("careOf")
+			.withCity("city")
+			.withStreet("street")
+			.withtPostalCode("zipCode") : AddressDetails.create();
 	}
 
 	public static Invoice createInvoiceInstance(boolean validInvoice, Type type) {
 		return Invoice.create()
-				.withCustomerId("customerId")
-				.withCustomerReference(type == EXTERNAL && !validInvoice ? null : "customerReference")
-				.withDescription("description")
-				.withOurReference(type == INTERNAL && !validInvoice ? null : "reference")
-				.withReferenceId(type == INTERNAL && !validInvoice ? null : "referenceId")
-				.withTotalAmount(validInvoice ? null : 123f);
+			.withCustomerId("customerId")
+			.withCustomerReference(type == EXTERNAL && !validInvoice ? null : "customerReference")
+			.withDescription("description")
+			.withOurReference(type == INTERNAL && !validInvoice ? null : "reference")
+			.withReferenceId(type == INTERNAL && !validInvoice ? null : "referenceId")
+			.withTotalAmount(validInvoice ? null : 123f);
 	}
 
 	public static InvoiceRow createInvoiceRowInstance(boolean validInvoiceRows, Type type) {
 		return InvoiceRow.create()
-				.withAccountInformation(createAccountInformationInstance(validInvoiceRows))
-				.withCostPerUnit(123f)
-				.withDescriptions(List.of(validInvoiceRows ? "description" : "a longer description than thirty characters"))
-				.withDetailedDescriptions(validInvoiceRows && INTERNAL == type ? null : List.of("detailedDescription"))
-				.withQuantity(1)
-				.withTotalAmount(validInvoiceRows ? null : 123f)
-				.withVatCode(validInvoiceRows ? INTERNAL == type ? null : "00" : INTERNAL == type ? "00" : null);
+			.withAccountInformation(createAccountInformationInstance(validInvoiceRows))
+			.withCostPerUnit(123f)
+			.withDescriptions(List.of(validInvoiceRows ? "description" : "a longer description than thirty characters"))
+			.withDetailedDescriptions(validInvoiceRows && INTERNAL == type ? null : List.of("detailedDescription"))
+			.withQuantity(1)
+			.withTotalAmount(validInvoiceRows ? null : 123f)
+			.withVatCode(validInvoiceRows ? INTERNAL == type ? null : "00" : INTERNAL == type ? "00" : null);
 	}
 
 	public static AccountInformation createAccountInformationInstance(boolean validAccountInformation) {
 		return validAccountInformation ? AccountInformation.create()
-				.withCounterpart("counterPart")
-				.withDepartment("department")
-				.withCostCenter("costCenter")
-				.withSubaccount("subAccount") : AccountInformation.create();
+			.withCounterpart("counterPart")
+			.withDepartment("department")
+			.withCostCenter("costCenter")
+			.withSubaccount("subAccount") : AccountInformation.create();
 	}
 }

--- a/src/test/java/se/sundsvall/billingpreprocessor/api/BillingRecordsCreateResourceFailureTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/api/BillingRecordsCreateResourceFailureTest.java
@@ -118,7 +118,7 @@ class BillingRecordsCreateResourceFailureTest {
 			tuple("billingRecord", "invoice.referenceId is mandatory when billing record is of type INTERNAL"),
 			tuple("billingRecord", "when accountInformation is present costCenter, subaccount, department and counterpart are mandatory"),
 			tuple("category", "must be one of ACCESS_CARD or SALARY_AND_PENSION"),
-			tuple("certified", "must be null"),
+			tuple("approved", "must be null"),
 			tuple("created", "must be null"),
 			tuple("id", "must be null"),
 			tuple("invoice.invoiceRows[0].descriptions[0]", "size must be between 1 and 30"),
@@ -159,7 +159,7 @@ class BillingRecordsCreateResourceFailureTest {
 			tuple("billingRecord", "issuer must have partyId when billing record is of type EXTERNAL"),
 			tuple("billingRecord", "when accountInformation is present costCenter, subaccount, department and counterpart are mandatory"),
 			tuple("category", "must be one of ACCESS_CARD or SALARY_AND_PENSION"),
-			tuple("certified", "must be null"),
+			tuple("approved", "must be null"),
 			tuple("created", "must be null"),
 			tuple("id", "must be null"),
 			tuple("invoice.invoiceRows[0].descriptions[0]", "size must be between 1 and 30"),
@@ -173,10 +173,10 @@ class BillingRecordsCreateResourceFailureTest {
 
 	@ParameterizedTest
 	@EnumSource(value = Type.class)
-	void createBillingRecordWithStatusCertifiedAndNoCertifiedBy(Type type) {
+	void createBillingRecordWithStatusApprovedAndNoApprovedBy(Type type) {
 		// Parameter values
 		final var request = createBillingRecordInstance(type, true)
-			.withCertifiedBy(null)
+			.withApprovedBy(null)
 			.withInvoice(createInvoiceInstance(true, type).withInvoiceRows(List.of(createInvoiceRowInstance(true, type))))
 			.withIssuer(createIssuerInstance(true).withAddressDetails(createAddressDetailsInstance(true)));
 
@@ -194,7 +194,7 @@ class BillingRecordsCreateResourceFailureTest {
 		assertThat(response.getTitle()).isEqualTo("Constraint Violation");
 		assertThat(response.getStatus()).isEqualTo(BAD_REQUEST);
 		assertThat(response.getViolations()).extracting(Violation::getField, Violation::getMessage).containsExactlyInAnyOrder(
-			tuple("billingRecord", "certifiedBy must be present when status is CERTIFIED"));
+			tuple("billingRecord", "approvedBy must be present when status is APPROVED"));
 
 		// Verification
 		verifyNoInteractions(serviceMock);

--- a/src/test/java/se/sundsvall/billingpreprocessor/api/BillingRecordsUpdateResourceFailureTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/api/BillingRecordsUpdateResourceFailureTest.java
@@ -153,7 +153,7 @@ class BillingRecordsUpdateResourceFailureTest {
 			tuple("billingRecord", "invoice.referenceId is mandatory when billing record is of type INTERNAL"),
 			tuple("billingRecord", "when accountInformation is present costCenter, subaccount, department and counterpart are mandatory"),
 			tuple("category", "must be one of ACCESS_CARD or SALARY_AND_PENSION"),
-			tuple("certified", "must be null"),
+			tuple("approved", "must be null"),
 			tuple("created", "must be null"),
 			tuple("id", "must be null"),
 			tuple("invoice.invoiceRows[0].descriptions[0]", "size must be between 1 and 30"),
@@ -195,7 +195,7 @@ class BillingRecordsUpdateResourceFailureTest {
 			tuple("billingRecord", "must contain vat code information on invoice rows when billing record is of type EXTERNAL"),
 			tuple("billingRecord", "when accountInformation is present costCenter, subaccount, department and counterpart are mandatory"),
 			tuple("category", "must be one of ACCESS_CARD or SALARY_AND_PENSION"),
-			tuple("certified", "must be null"),
+			tuple("approved", "must be null"),
 			tuple("created", "must be null"),
 			tuple("id", "must be null"),
 			tuple("invoice.invoiceRows[0].descriptions[0]", "size must be between 1 and 30"),
@@ -209,11 +209,11 @@ class BillingRecordsUpdateResourceFailureTest {
 
 	@ParameterizedTest
 	@EnumSource(value = Type.class)
-	void updateBillingRecordWithStatusCertifiedAndNoCertifiedBy(Type type) {
+	void updateBillingRecordWithStatusApprovedAndNoApprovedBy(Type type) {
 		// Parameter values
 		final var uuid = randomUUID().toString();
 		final var request = createBillingRecordInstance(type, true)
-			.withCertifiedBy(null)
+			.withApprovedBy(null)
 			.withInvoice(createInvoiceInstance(true, type).withInvoiceRows(List.of(createInvoiceRowInstance(true, type))))
 			.withIssuer(createIssuerInstance(true).withAddressDetails(createAddressDetailsInstance(true)));
 
@@ -231,7 +231,7 @@ class BillingRecordsUpdateResourceFailureTest {
 		assertThat(response.getTitle()).isEqualTo("Constraint Violation");
 		assertThat(response.getStatus()).isEqualTo(BAD_REQUEST);
 		assertThat(response.getViolations()).extracting(Violation::getField, Violation::getMessage).containsExactlyInAnyOrder(
-			tuple("billingRecord", "certifiedBy must be present when status is CERTIFIED"));
+			tuple("billingRecord", "approvedBy must be present when status is APPROVED"));
 
 		// Verification
 		verifyNoInteractions(serviceMock);

--- a/src/test/java/se/sundsvall/billingpreprocessor/api/model/BillingRecordTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/api/model/BillingRecordTest.java
@@ -39,8 +39,8 @@ class BillingRecordTest {
 	@Test
 	void testBuilderMethods() {
 		final var category = "category";
-		final var certified = now();
-		final var certifiedBy = "certifiedBy";
+		final var approved = now();
+		final var approvedBy = "approvedBy";
 		final var created = now().minusDays(14);
 		final var id = "id";
 		final var invoice = Invoice.create();
@@ -51,8 +51,8 @@ class BillingRecordTest {
 
 		final var bean = BillingRecord.create()
 			.withCategory(category)
-			.withCertified(certified)
-			.withCertifiedBy(certifiedBy)
+			.withApproved(approved)
+			.withApprovedBy(approvedBy)
 			.withCreated(created)
 			.withId(id)
 			.withInvoice(invoice)
@@ -62,8 +62,8 @@ class BillingRecordTest {
 			.withType(type);
 
 		assertThat(bean.getCategory()).isEqualTo(category);
-		assertThat(bean.getCertified()).isEqualTo(certified);
-		assertThat(bean.getCertifiedBy()).isEqualTo(certifiedBy);
+		assertThat(bean.getApproved()).isEqualTo(approved);
+		assertThat(bean.getApprovedBy()).isEqualTo(approvedBy);
 		assertThat(bean.getCreated()).isEqualTo(created);
 		assertThat(bean.getId()).isEqualTo(id);
 		assertThat(bean.getInvoice()).isEqualTo(invoice);

--- a/src/test/java/se/sundsvall/billingpreprocessor/api/model/enums/StatusTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/api/model/enums/StatusTest.java
@@ -1,7 +1,7 @@
 package se.sundsvall.billingpreprocessor.api.model.enums;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static se.sundsvall.billingpreprocessor.api.model.enums.Status.CERTIFIED;
+import static se.sundsvall.billingpreprocessor.api.model.enums.Status.APPROVED;
 import static se.sundsvall.billingpreprocessor.api.model.enums.Status.INVOICED;
 import static se.sundsvall.billingpreprocessor.api.model.enums.Status.NEW;
 import static se.sundsvall.billingpreprocessor.api.model.enums.Status.REJECTED;
@@ -12,12 +12,12 @@ class StatusTest {
 
 	@Test
 	void enums() {
-		assertThat(Status.values()).containsExactlyInAnyOrder(CERTIFIED, INVOICED, NEW, REJECTED);
+		assertThat(Status.values()).containsExactlyInAnyOrder(APPROVED, INVOICED, NEW, REJECTED);
 	}
 
 	@Test
 	void enumValues() {
-		assertThat(CERTIFIED).hasToString("CERTIFIED");
+		assertThat(APPROVED).hasToString("APPROVED");
 		assertThat(INVOICED).hasToString("INVOICED");
 		assertThat(NEW).hasToString("NEW");
 		assertThat(REJECTED).hasToString("REJECTED");

--- a/src/test/java/se/sundsvall/billingpreprocessor/api/validation/impl/ValidApprovedByConstraintValidatorTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/api/validation/impl/ValidApprovedByConstraintValidatorTest.java
@@ -6,7 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-import static se.sundsvall.billingpreprocessor.api.model.enums.Status.CERTIFIED;
+import static se.sundsvall.billingpreprocessor.api.model.enums.Status.APPROVED;
 
 import javax.validation.ConstraintValidatorContext;
 import javax.validation.ConstraintValidatorContext.ConstraintViolationBuilder;
@@ -22,7 +22,7 @@ import se.sundsvall.billingpreprocessor.api.model.BillingRecord;
 import se.sundsvall.billingpreprocessor.api.model.enums.Status;
 
 @ExtendWith(MockitoExtension.class)
-class ValidCertifiedByConstraintValidatorTest {
+class ValidApprovedByConstraintValidatorTest {
 
 	@Mock
 	private ConstraintValidatorContext contextMock;
@@ -30,31 +30,31 @@ class ValidCertifiedByConstraintValidatorTest {
 	@Mock
 	private ConstraintViolationBuilder builderMock;
 
-	private ValidCertifiedByConstraintValidator validator = new ValidCertifiedByConstraintValidator();
+	private ValidApprovedByConstraintValidator validator = new ValidApprovedByConstraintValidator();
 
 	@ParameterizedTest
-	@EnumSource(mode = EXCLUDE, names = "CERTIFIED", value = Status.class)
-	void withStatusNotEqualToCertifiedAndNoCertifiedByDefined(Status status) {
+	@EnumSource(mode = EXCLUDE, names = "APPROVED", value = Status.class)
+	void withStatusNotEqualToApprovedAndNoApprovedByDefined(Status status) {
 		assertThat(validator.isValid(BillingRecord.create().withStatus(status), contextMock)).isTrue();
 
 		verifyNoInteractions(contextMock, builderMock);
 	}
 
 	@Test
-	void withStatusEqualToCertifiedAndCertifiedByDefined() {
-		assertThat(validator.isValid(BillingRecord.create().withStatus(CERTIFIED).withCertifiedBy("certifiedBy"), contextMock)).isTrue();
+	void withStatusEqualToApprovedAndApprovedByDefined() {
+		assertThat(validator.isValid(BillingRecord.create().withStatus(APPROVED).withApprovedBy("approvedBy"), contextMock)).isTrue();
 
 		verifyNoInteractions(contextMock, builderMock);
 	}
 
 	@Test
-	void withStatusEqualToCertifiedAndNoCertifiedByDefined() {
+	void withStatusEqualToApprovedAndNoApprovedByDefined() {
 		when(contextMock.buildConstraintViolationWithTemplate(any())).thenReturn(builderMock);
 
-		assertThat(validator.isValid(BillingRecord.create().withStatus(CERTIFIED), contextMock)).isFalse();
+		assertThat(validator.isValid(BillingRecord.create().withStatus(APPROVED), contextMock)).isFalse();
 
 		verify(contextMock).disableDefaultConstraintViolation();
-		verify(contextMock).buildConstraintViolationWithTemplate("certifiedBy must be present when status is CERTIFIED");
+		verify(contextMock).buildConstraintViolationWithTemplate("approvedBy must be present when status is APPROVED");
 		verify(builderMock).addConstraintViolation();
 	}
 }

--- a/src/test/java/se/sundsvall/billingpreprocessor/integration/db/BillingRecordRepositoryTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/integration/db/BillingRecordRepositoryTest.java
@@ -6,7 +6,7 @@ import static java.util.stream.Collectors.toCollection;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.assertj.core.api.Assertions.within;
-import static se.sundsvall.billingpreprocessor.api.model.enums.Status.CERTIFIED;
+import static se.sundsvall.billingpreprocessor.api.model.enums.Status.APPROVED;
 import static se.sundsvall.billingpreprocessor.api.model.enums.Status.NEW;
 import static se.sundsvall.billingpreprocessor.api.model.enums.Status.REJECTED;
 import static se.sundsvall.billingpreprocessor.api.model.enums.Type.EXTERNAL;
@@ -88,9 +88,9 @@ class BillingRecordRepositoryTest {
 	private static final String PARTY_ID = "partyId";
 	private static final String USER_ID = "userId";
 	private static final String CATEGORY = "category";
-	private static final OffsetDateTime CERTIFIED_TIMESTAMP = now().plusDays(3);
-	private static final String CERTIFIED_BY = "certifiedBy";
-	private static final Status STATUS = CERTIFIED;
+	private static final OffsetDateTime APPROVED_TIMESTAMP = now().plusDays(3);
+	private static final String APPROVED_BY = "approvedBy";
+	private static final Status STATUS = APPROVED;
 	private static final Type TYPE = EXTERNAL;
 
 	@Autowired
@@ -120,8 +120,8 @@ class BillingRecordRepositoryTest {
 	private static void verifybillingRecord(final BillingRecordEntity billingRecord) {
 		assertThat(billingRecord).isNotNull();
 		assertThat(billingRecord.getCategory()).isEqualTo(CATEGORY);
-		assertThat(billingRecord.getCertified()).isEqualTo(CERTIFIED_TIMESTAMP);
-		assertThat(billingRecord.getCertifiedBy()).isEqualTo(CERTIFIED_BY);
+		assertThat(billingRecord.getApproved()).isEqualTo(APPROVED_TIMESTAMP);
+		assertThat(billingRecord.getApprovedBy()).isEqualTo(APPROVED_BY);
 		assertThat(billingRecord.getCreated()).isCloseTo(now(), within(2, SECONDS));
 		assertThat(billingRecord.getId()).isNotNull();
 		assertThat(billingRecord.getInvoice()).isNotNull();
@@ -202,7 +202,7 @@ class BillingRecordRepositoryTest {
 
 	@Test
 	void findWithSpecification() {
-		Specification<BillingRecordEntity> specification = new FilterSpecification<>("(category : 'ACCESS_CARD' and status : 'CERTIFIED')");
+		Specification<BillingRecordEntity> specification = new FilterSpecification<>("(category : 'ACCESS_CARD' and status : 'APPROVED')");
 		Pageable pageable = PageRequest.of(0, 20);
 
 		final var matches = repository.findAll(specification, pageable);
@@ -213,7 +213,7 @@ class BillingRecordRepositoryTest {
 		assertThat(matches.getTotalPages()).isEqualTo(1);
 		assertThat(matches)
 			.extracting(BillingRecordEntity::getId, BillingRecordEntity::getCategory, BillingRecordEntity::getStatus).containsExactly(
-				tuple("1310ee8b-ecf9-4fe1-ab9d-f19153b19d06", "ACCESS_CARD", CERTIFIED));
+				tuple("1310ee8b-ecf9-4fe1-ab9d-f19153b19d06", "ACCESS_CARD", APPROVED));
 	}
 
 	@Test
@@ -230,7 +230,7 @@ class BillingRecordRepositoryTest {
 		assertThat(matches)
 			.extracting(BillingRecordEntity::getId, BillingRecordEntity::getCategory, BillingRecordEntity::getStatus).containsExactlyInAnyOrder(
 				tuple("71258e7d-5285-46ce-b9b2-877f8cad8edd", "ACCESS_CARD", NEW),
-				tuple("1310ee8b-ecf9-4fe1-ab9d-f19153b19d06", "ACCESS_CARD", CERTIFIED),
+				tuple("1310ee8b-ecf9-4fe1-ab9d-f19153b19d06", "ACCESS_CARD", APPROVED),
 				tuple("83e4d599-5b4d-431c-8ebc-81192e9401ee", "SALARY_AND_PENSION", NEW));
 	}
 
@@ -342,8 +342,8 @@ class BillingRecordRepositoryTest {
 	private static BillingRecordEntity createbillingRecord() {
 		return BillingRecordEntity.create()
 			.withCategory(CATEGORY)
-			.withCertified(CERTIFIED_TIMESTAMP)
-			.withCertifiedBy(CERTIFIED_BY)
+			.withApproved(APPROVED_TIMESTAMP)
+			.withApprovedBy(APPROVED_BY)
 			.withStatus(STATUS)
 			.withType(TYPE);
 	}

--- a/src/test/java/se/sundsvall/billingpreprocessor/integration/db/SchemaVerificationTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/integration/db/SchemaVerificationTest.java
@@ -17,7 +17,7 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("junit")
 class SchemaVerificationTest {
 
-	private static final String STORED_SCHEMA_FILE = "db/scripts/schema.sql";
+	private static final String STORED_SCHEMA_FILE = "db/schema/schema.sql";
 
 	@Value("${spring.jpa.properties.javax.persistence.schema-generation.scripts.create-target}")
 	private String generatedSchemaFile;

--- a/src/test/java/se/sundsvall/billingpreprocessor/integration/db/model/BillingRecordEntityTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/integration/db/model/BillingRecordEntityTest.java
@@ -39,8 +39,8 @@ class BillingRecordEntityTest {
 	@Test
 	void hasValidBuilderMethods() {
 		final var category = "category";
-		final var certified = now().minusWeeks(2);
-		final var certifiedBy = "certifiedBy";
+		final var approved = now().minusWeeks(2);
+		final var approvedBy = "approvedBy";
 		final var created = now().minusWeeks(3);
 		final var id = "id";
 		final var invoice = InvoiceEntity.create();
@@ -51,8 +51,8 @@ class BillingRecordEntityTest {
 
 		final var entity = BillingRecordEntity.create()
 			.withCategory(category)
-			.withCertified(certified)
-			.withCertifiedBy(certifiedBy)
+			.withApproved(approved)
+			.withApprovedBy(approvedBy)
 			.withCreated(created)
 			.withId(id)
 			.withInvoice(invoice)
@@ -63,8 +63,8 @@ class BillingRecordEntityTest {
 
 		assertThat(entity).hasNoNullFieldsOrProperties();
 		assertThat(entity.getCategory()).isEqualTo(category);
-		assertThat(entity.getCertified()).isEqualTo(certified);
-		assertThat(entity.getCertifiedBy()).isEqualTo(certifiedBy);
+		assertThat(entity.getApproved()).isEqualTo(approved);
+		assertThat(entity.getApprovedBy()).isEqualTo(approvedBy);
 		assertThat(entity.getCreated()).isEqualTo(created);
 		assertThat(entity.getId()).isEqualTo(id);
 		assertThat(entity.getInvoice()).isEqualTo(invoice);

--- a/src/test/java/se/sundsvall/billingpreprocessor/service/mapper/BillingRecordMapperTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/service/mapper/BillingRecordMapperTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.groups.Tuple.tuple;
 import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
-import static se.sundsvall.billingpreprocessor.api.model.enums.Status.CERTIFIED;
+import static se.sundsvall.billingpreprocessor.api.model.enums.Status.APPROVED;
 import static se.sundsvall.billingpreprocessor.api.model.enums.Type.EXTERNAL;
 import static se.sundsvall.billingpreprocessor.integration.db.model.DescriptionType.DETAILED;
 import static se.sundsvall.billingpreprocessor.integration.db.model.DescriptionType.STANDARD;
@@ -45,10 +45,10 @@ class BillingRecordMapperTest {
 	// billingRecord constants
 	private static final String ID = randomUUID().toString();
 	private static final String CATEGORY = "category";
-	private static final String CERTIFIED_BY = "certifiedBy";
-	private static final Status STATUS = CERTIFIED;
+	private static final String APPROVED_BY = "approvedBy";
+	private static final Status STATUS = APPROVED;
 	private static final Type TYPE = EXTERNAL;
-	private static final OffsetDateTime CERTIFIED_TIMESTAMP = now();
+	private static final OffsetDateTime APPROVED_TIMESTAMP = now();
 	private static final OffsetDateTime CREATED_TIMESTAMP = now().minusDays(2);
 	private static final OffsetDateTime MODIFIED_TIMESTAMP = now().minusDays(1);
 
@@ -103,8 +103,8 @@ class BillingRecordMapperTest {
 
 		// Assert billing record entity values
 		assertThat(billingRecordEntity.getCategory()).isEqualTo(CATEGORY);
-		assertThat(billingRecordEntity.getCertified()).isCloseTo(now(), within(2, SECONDS));
-		assertThat(billingRecordEntity.getCertifiedBy()).isEqualTo(CERTIFIED_BY);
+		assertThat(billingRecordEntity.getApproved()).isCloseTo(now(), within(2, SECONDS));
+		assertThat(billingRecordEntity.getApprovedBy()).isEqualTo(APPROVED_BY);
 		assertThat(billingRecordEntity.getStatus()).isEqualTo(STATUS);
 		assertThat(billingRecordEntity.getType()).isEqualTo(TYPE);
 
@@ -233,48 +233,48 @@ class BillingRecordMapperTest {
 	}
 
 	@ParameterizedTest
-	@EnumSource(value = Status.class, names = "CERTIFIED", mode = EXCLUDE)
-	void verifyNoCertifiedDateOrCertifiedBy(Status status) {
+	@EnumSource(value = Status.class, names = "APPROVED", mode = EXCLUDE)
+	void verifyNoApprovedDateOrApprovedBy(Status status) {
 		final var billingRecord = createbillingRecord().withStatus(status);
 		final var billingRecordEntity = BillingRecordMapper.toBillingRecordEntity(billingRecord);
 
-		assertThat(billingRecordEntity.getCertified()).isNull();
-		assertThat(billingRecordEntity.getCertifiedBy()).isNull();
+		assertThat(billingRecordEntity.getApproved()).isNull();
+		assertThat(billingRecordEntity.getApprovedBy()).isNull();
 	}
 
 	@ParameterizedTest
-	@EnumSource(value = Status.class, names = "CERTIFIED", mode = EXCLUDE)
-	void updatebillingRecordEntityFromOtherStatusToCertifiedStatus(Status status) {
-		final var billingEntity = BillingRecordMapper.toBillingRecordEntity(createbillingRecord().withStatus(status).withCertifiedBy(null));
+	@EnumSource(value = Status.class, names = "APPROVED", mode = EXCLUDE)
+	void updatebillingRecordEntityFromOtherStatusToApprovedStatus(Status status) {
+		final var billingEntity = BillingRecordMapper.toBillingRecordEntity(createbillingRecord().withStatus(status).withApprovedBy(null));
 		final var billingRecord = createbillingRecord();
 		final var updatedEntity = BillingRecordMapper.updateEntity(billingEntity, billingRecord);
 
-		assertThat(updatedEntity.getCertified()).isCloseTo(now(), within(2, SECONDS));
-		assertThat(updatedEntity.getCertifiedBy()).isEqualTo(CERTIFIED_BY);
+		assertThat(updatedEntity.getApproved()).isCloseTo(now(), within(2, SECONDS));
+		assertThat(updatedEntity.getApprovedBy()).isEqualTo(APPROVED_BY);
 		assertThat(updatedEntity.getModified()).isCloseTo(now(), within(2, SECONDS));
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = "RANDOM_CERTIFIED_BY")
+	@ValueSource(strings = "RANDOM_APPROVED_BY")
 	@NullSource
-	void updatebillingRecordEntityWhenStatusCertified(String certifiedBy) {
+	void updatebillingRecordEntityWhenStatusApproved(String approvedBy) {
 		final var billingEntity = BillingRecordMapper.toBillingRecordEntity(createbillingRecord());
-		final var certifiedTimestamp = billingEntity.getCertified();
-		final var updatedEntity = BillingRecordMapper.updateEntity(billingEntity, createbillingRecord().withCertifiedBy(certifiedBy));
+		final var approvedTimestamp = billingEntity.getApproved();
+		final var updatedEntity = BillingRecordMapper.updateEntity(billingEntity, createbillingRecord().withApprovedBy(approvedBy));
 
-		assertThat(updatedEntity.getCertified()).isEqualTo(certifiedTimestamp);
-		assertThat(updatedEntity.getCertifiedBy()).isEqualTo(CERTIFIED_BY);
+		assertThat(updatedEntity.getApproved()).isEqualTo(approvedTimestamp);
+		assertThat(updatedEntity.getApprovedBy()).isEqualTo(APPROVED_BY);
 		assertThat(updatedEntity.getModified()).isCloseTo(now(), within(2, SECONDS));
 	}
 
 	@ParameterizedTest
-	@EnumSource(value = Status.class, names = "CERTIFIED", mode = EXCLUDE)
-	void updatebillingRecordEntityFromStatusCertifiedToOtherStatus(Status status) {
+	@EnumSource(value = Status.class, names = "APPROVED", mode = EXCLUDE)
+	void updatebillingRecordEntityFromStatusApprovedToOtherStatus(Status status) {
 		final var billingEntity = BillingRecordMapper.toBillingRecordEntity(createbillingRecord());
-		final var certifiedTimestamp = billingEntity.getCertified();
+		final var approvedTimestamp = billingEntity.getApproved();
 		final var updatedEntity = BillingRecordMapper.updateEntity(billingEntity, createbillingRecord());
 
-		assertThat(updatedEntity.getCertified()).isEqualTo(certifiedTimestamp);
+		assertThat(updatedEntity.getApproved()).isEqualTo(approvedTimestamp);
 		assertThat(updatedEntity.getModified()).isCloseTo(now(), within(2, SECONDS));
 	}
 
@@ -294,8 +294,8 @@ class BillingRecordMapperTest {
 
 		// Assert billing record values
 		assertThat(billingRecord.getCategory()).isEqualTo(CATEGORY);
-		assertThat(billingRecord.getCertified()).isEqualTo(CERTIFIED_TIMESTAMP);
-		assertThat(billingRecord.getCertifiedBy()).isEqualTo(CERTIFIED_BY);
+		assertThat(billingRecord.getApproved()).isEqualTo(APPROVED_TIMESTAMP);
+		assertThat(billingRecord.getApprovedBy()).isEqualTo(APPROVED_BY);
 		assertThat(billingRecord.getCreated()).isEqualTo(CREATED_TIMESTAMP);
 		assertThat(billingRecord.getId()).isEqualTo(ID);
 		assertThat(billingRecord.getModified()).isEqualTo(MODIFIED_TIMESTAMP);
@@ -393,8 +393,8 @@ class BillingRecordMapperTest {
 	private static BillingRecordEntity createbillingRecordEntity() {
 		final var billingRecordEntity = BillingRecordEntity.create()
 			.withCategory(CATEGORY)
-			.withCertified(CERTIFIED_TIMESTAMP)
-			.withCertifiedBy(CERTIFIED_BY)
+			.withApproved(APPROVED_TIMESTAMP)
+			.withApprovedBy(APPROVED_BY)
 			.withCreated(CREATED_TIMESTAMP)
 			.withId(ID)
 			.withModified(MODIFIED_TIMESTAMP)
@@ -511,7 +511,7 @@ class BillingRecordMapperTest {
 	private static BillingRecord createbillingRecord() {
 		return BillingRecord.create()
 			.withCategory(CATEGORY)
-			.withCertifiedBy(CERTIFIED_BY)
+			.withApprovedBy(APPROVED_BY)
 			.withInvoice(createInvoice())
 			.withIssuer(createIssuer())
 			.withStatus(STATUS)

--- a/src/test/resources/db/schema/schema.sql
+++ b/src/test/resources/db/schema/schema.sql
@@ -1,9 +1,9 @@
 
     create table billing_record (
        id varchar(255) not null,
+        approved datetime(6),
+        approved_by varchar(255),
         category varchar(255) not null,
-        certified datetime(6),
-        certified_by varchar(255),
         created datetime(6),
         modified datetime(6),
         status varchar(255) not null,

--- a/src/test/resources/db/scripts/testdata-it.sql
+++ b/src/test/resources/db/scripts/testdata-it.sql
@@ -1,9 +1,9 @@
 -------------------------------------
 -- Billling records
 -------------------------------------
-INSERT INTO billing_record (id, category, certified, certified_by, created, modified, status, `type`)
+INSERT INTO billing_record (id, category, approved, approved_by, created, modified, status, `type`)
 VALUES	('71258e7d-5285-46ce-b9b2-877f8cad8edd', 'ACCESS_CARD', NULL, NULL, '2022-06-20 11:17:36.795', NULL, 'NEW', 'INTERNAL'),
-		('1310ee8b-ecf9-4fe1-ab9d-f19153b19d06', 'ACCESS_CARD', '2022-06-30 08:52:25.112', 'JOE01DOE', '2022-06-25 16:43:12.553', '2022-06-30 08:52:25.112', 'CERTIFIED', 'INTERNAL'),
+		('1310ee8b-ecf9-4fe1-ab9d-f19153b19d06', 'ACCESS_CARD', '2022-06-30 08:52:25.112', 'JOE01DOE', '2022-06-25 16:43:12.553', '2022-06-30 08:52:25.112', 'APPROVED', 'INTERNAL'),
 		('83e4d599-5b4d-431c-8ebc-81192e9401ee', 'SALARY_AND_PENSION', NULL, NULL, '2022-06-25 16:43:12.553', NULL, 'NEW', 'EXTERNAL');
 
 -------------------------------------

--- a/src/test/resources/db/scripts/testdata-junit.sql
+++ b/src/test/resources/db/scripts/testdata-junit.sql
@@ -1,9 +1,9 @@
 -------------------------------------
 -- Billling records
 -------------------------------------
-INSERT INTO billing_record (id, category, certified, certified_by, created, modified, status, `type`)
+INSERT INTO billing_record (id, category, approved, approved_by, created, modified, status, `type`)
 VALUES	('71258e7d-5285-46ce-b9b2-877f8cad8edd', 'ACCESS_CARD', NULL, NULL, '2022-06-20 11:17:36.795', NULL, 'NEW', 'INTERNAL'),
-		('1310ee8b-ecf9-4fe1-ab9d-f19153b19d06', 'ACCESS_CARD', '2022-06-30 08:52:25.112', 'JOE01DOE', '2022-06-25 16:43:12.553', '2022-06-30 08:52:25.112', 'CERTIFIED', 'INTERNAL'),
+		('1310ee8b-ecf9-4fe1-ab9d-f19153b19d06', 'ACCESS_CARD', '2022-06-30 08:52:25.112', 'JOE01DOE', '2022-06-25 16:43:12.553', '2022-06-30 08:52:25.112', 'APPROVED', 'INTERNAL'),
 		('83e4d599-5b4d-431c-8ebc-81192e9401ee', 'SALARY_AND_PENSION', NULL, NULL, '2022-06-25 16:43:12.553', NULL, 'NEW', 'EXTERNAL');
 
 -------------------------------------


### PR DESCRIPTION
- Renamed status value CERTIFIED to APPROVED in API enum
- Updated backing database table column names from certified and certified_by to approved and approved_by
- Moved schema to own sub directory