### PR TITLE
UF-7377: Extended to use party service for customers missing legalid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 ### Local config ###
 .env
+application-default.*
 
 ### Java ###
 # Compiled class file

--- a/src/main/java/se/sundsvall/billingpreprocessor/Application.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/Application.java
@@ -2,9 +2,12 @@ package se.sundsvall.billingpreprocessor;
 
 import static org.springframework.boot.SpringApplication.run;
 
+import org.springframework.cloud.openfeign.EnableFeignClients;
+
 import se.sundsvall.dept44.ServiceApplication;
 
 @ServiceApplication
+@EnableFeignClients
 public class Application {
 	public static void main(String... args) {
 		run(Application.class, args);

--- a/src/main/java/se/sundsvall/billingpreprocessor/Constants.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/Constants.java
@@ -3,8 +3,6 @@ package se.sundsvall.billingpreprocessor;
 public final class Constants {
 	private Constants() {}
 
-	public static final String GENERATING_SYSTEM = "BillingPreProcessor";
-	public static final String EXTERNAL_INVOICE_TYPE = "Extern debitering";
 	public static final byte[] EMPTY_ARRAY = new byte[0];
 
 	public static final String ERROR_ACCOUNT_INFORMATION_NOT_PRESENT = "Account information is not present";
@@ -28,4 +26,7 @@ public final class Constants {
 	public static final String ERROR_SUBACCOUNT_NOT_PRESENT = "Sub account is not present";
 	public static final String ERROR_TOTAL_AMOUNT_NOT_PRESENT = "Total amount is not present";
 	public static final String ERROR_VAT_CODE_NOT_PRESENT = "Vat code is not present";
+
+	public static final String EXTERNAL_INVOICE_TYPE = "Extern debitering";
+	public static final String GENERATING_SYSTEM = "BillingPreProcessor";
 }

--- a/src/main/java/se/sundsvall/billingpreprocessor/integration/party/PartyConfiguration.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/integration/party/PartyConfiguration.java
@@ -7,8 +7,7 @@ import java.util.List;
 import org.springframework.cloud.openfeign.FeignBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.security.oauth2.client.registration.ClientRegistration;
-import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 
 import se.sundsvall.dept44.configuration.feign.FeignConfiguration;
 import se.sundsvall.dept44.configuration.feign.FeignMultiCustomizer;
@@ -20,16 +19,11 @@ class PartyConfiguration {
     static final String CLIENT_ID = "party";
 
     @Bean
-    FeignBuilderCustomizer feignBuilderCustomizer(final PartyProperties partyProperties) {
-        return FeignMultiCustomizer.create()
-            .withRetryableOAuth2InterceptorForClientRegistration(ClientRegistration.withRegistrationId(CLIENT_ID)
-                .tokenUri(partyProperties.oauth2().tokenUri())
-                .clientId(partyProperties.oauth2().clientId())
-                .clientSecret(partyProperties.oauth2().clientSecret())
-                .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
-                .build())
+	FeignBuilderCustomizer feignBuilderCustomizer(final PartyProperties partyProperties, ClientRegistrationRepository clientRegistrationRepository) {
+		return FeignMultiCustomizer.create()
             .withErrorDecoder(new ProblemErrorDecoder(CLIENT_ID, List.of(NOT_FOUND.value())))
-            .withRequestTimeoutsInSeconds(partyProperties.connectTimeout(), partyProperties.readTimeout())
-            .composeCustomizersToOne();
-    }
+			.withRequestTimeoutsInSeconds(partyProperties.connectTimeout(), partyProperties.readTimeout())
+			.withRetryableOAuth2InterceptorForClientRegistration(clientRegistrationRepository.findByRegistrationId(CLIENT_ID))
+			.composeCustomizersToOne();
+	}
 }

--- a/src/main/java/se/sundsvall/billingpreprocessor/integration/party/PartyProperties.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/integration/party/PartyProperties.java
@@ -1,35 +1,8 @@
 package se.sundsvall.billingpreprocessor.integration.party;
 
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.DefaultValue;
-import org.springframework.validation.annotation.Validated;
 
-@Validated
 @ConfigurationProperties("integration.party")
-record PartyProperties(
-
-        @NotBlank
-        String url,
-
-        @Valid
-        @NotNull
-        Oauth2 oauth2,
-
-        @DefaultValue("10")
-        int connectTimeout,
-        @DefaultValue("20")
-        int readTimeout) {
-
-    record Oauth2(
-
-        @NotBlank
-        String tokenUri,
-        @NotBlank
-        String clientId,
-        @NotBlank
-        String clientSecret) { }
+record PartyProperties(@DefaultValue("10") int connectTimeout, @DefaultValue("20") int readTimeout) {
 }

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/creator/InternalInvoiceCreator.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/creator/InternalInvoiceCreator.java
@@ -10,7 +10,7 @@ import static se.sundsvall.billingpreprocessor.service.mapper.InternalInvoiceMap
 import static se.sundsvall.billingpreprocessor.service.mapper.InternalInvoiceMapper.toInvoiceFooter;
 import static se.sundsvall.billingpreprocessor.service.mapper.InternalInvoiceMapper.toInvoiceHeader;
 import static se.sundsvall.billingpreprocessor.service.mapper.InternalInvoiceMapper.toInvoiceRow;
-import static se.sundsvall.billingpreprocessor.service.util.ProblemUtil.createProblem;
+import static se.sundsvall.billingpreprocessor.service.util.ProblemUtil.createInternalServerErrorProblem;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -75,7 +75,7 @@ public class InternalInvoiceCreator {
 		invoiceWriter.write(toInvoiceDescriptionRow(billingRecord));
 
 		ofNullable(billingRecord.getInvoice())
-			.orElseThrow(createProblem("Invoice is not present"))
+			.orElseThrow(createInternalServerErrorProblem("Invoice is not present"))
 			.getInvoiceRows()
 			.forEach(row -> processInvoiceRow(invoiceWriter, row));
 

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/creator/LegalIdProvider.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/creator/LegalIdProvider.java
@@ -1,0 +1,33 @@
+package se.sundsvall.billingpreprocessor.service.creator;
+
+import static generated.se.sundsvall.party.PartyType.ENTERPRISE;
+import static generated.se.sundsvall.party.PartyType.PRIVATE;
+import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.zalando.problem.Status.INTERNAL_SERVER_ERROR;
+import static org.zalando.problem.Status.NOT_FOUND;
+import static se.sundsvall.billingpreprocessor.service.util.ProblemUtil.createProblem;
+
+import org.springframework.stereotype.Component;
+import org.zalando.problem.Problem;
+
+import se.sundsvall.billingpreprocessor.integration.party.PartyClient;
+
+@Component
+public class LegalIdProvider {
+	private final PartyClient partyClient;
+
+	public LegalIdProvider(PartyClient partyClient) {
+		this.partyClient = partyClient;
+	}
+
+	public String translateToLegalId(String partyId) {
+		if (isBlank(partyId)) {
+			throw Problem.valueOf(INTERNAL_SERVER_ERROR, "Party id is not present");
+		}
+
+		return partyClient.getLegalId(PRIVATE, partyId)
+			.or(() -> partyClient.getLegalId(ENTERPRISE, partyId))
+			.orElseThrow(createProblem(NOT_FOUND, format("PartyId '%s' could not be found as a private customer or an enterprise customer", partyId)));
+	}
+}

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/mapper/ExternalInvoiceMapper.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/mapper/ExternalInvoiceMapper.java
@@ -23,7 +23,7 @@ import static se.sundsvall.billingpreprocessor.Constants.ERROR_SUBACCOUNT_NOT_PR
 import static se.sundsvall.billingpreprocessor.Constants.ERROR_VAT_CODE_NOT_PRESENT;
 import static se.sundsvall.billingpreprocessor.integration.db.model.enums.DescriptionType.DETAILED;
 import static se.sundsvall.billingpreprocessor.integration.db.model.enums.DescriptionType.STANDARD;
-import static se.sundsvall.billingpreprocessor.service.util.ProblemUtil.createProblem;
+import static se.sundsvall.billingpreprocessor.service.util.ProblemUtil.createInternalServerErrorProblem;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -60,9 +60,9 @@ public class ExternalInvoiceMapper {
 	 */
 	public static FileHeaderRow toFileHeader(String generatingSystem, String invoiceType) {
 		return FileHeaderRow.create()
-			.withGeneratingSystem(ofNullable(generatingSystem).orElseThrow(createProblem(ERROR_GENERATING_SYSTEM_NOT_PRESENT)))
+			.withGeneratingSystem(ofNullable(generatingSystem).orElseThrow(createInternalServerErrorProblem(ERROR_GENERATING_SYSTEM_NOT_PRESENT)))
 			.withCreatedDate(LocalDate.now())
-			.withInvoiceType(ofNullable(invoiceType).orElseThrow(createProblem(ERROR_INVOICE_TYPE_NOT_PRESENT)));
+			.withInvoiceType(ofNullable(invoiceType).orElseThrow(createInternalServerErrorProblem(ERROR_INVOICE_TYPE_NOT_PRESENT)));
 	}
 
 	/**
@@ -74,15 +74,15 @@ public class ExternalInvoiceMapper {
 	 * @throws ThrowableProblem if any mandatory data is missing
 	 */
 	public static CustomerRow toCustomer(String legalId, BillingRecordEntity billingRecordEntity) {
-		final var recipientEntity = ofNullable(billingRecordEntity.getRecipient()).orElseThrow(createProblem(ERROR_RECIPIENT_NOT_PRESENT));
+		final var recipientEntity = ofNullable(billingRecordEntity.getRecipient()).orElseThrow(createInternalServerErrorProblem(ERROR_RECIPIENT_NOT_PRESENT));
 
 		return CustomerRow.create()
-			.withLegalId(ofNullable(legalId).orElseThrow(createProblem(ERROR_LEGALID_NOT_PRESENT)))
-			.withCustomerName(ofNullable(extractRecipientName(recipientEntity)).orElseThrow(createProblem(ERROR_RECIPIENT_NAME_NOT_PRESENT)))
+			.withLegalId(ofNullable(legalId).orElseThrow(createInternalServerErrorProblem(ERROR_LEGALID_NOT_PRESENT)))
+			.withCustomerName(ofNullable(extractRecipientName(recipientEntity)).orElseThrow(createInternalServerErrorProblem(ERROR_RECIPIENT_NAME_NOT_PRESENT)))
 			.withCareOf(recipientEntity.getAddressDetails().getCareOf())
-			.withStreetAddress(ofNullable(recipientEntity.getAddressDetails().getStreet()).orElseThrow(createProblem(ERROR_RECIPIENT_STREET_ADDRESS_NOT_PRESENT)))
-			.withZipCodeAndCity(ofNullable(extractZipCodeAndCity(recipientEntity.getAddressDetails())).orElseThrow(createProblem(ERROR_RECIPIENT_ZIPCODE_OR_CITY_NOT_PRESENT)))
-			.withCounterpart(ofNullable(extractCounterpart(billingRecordEntity.getInvoice())).orElseThrow(createProblem(ERROR_RECIPIENT_COUNTERPART_NOT_PRESENT)));
+			.withStreetAddress(ofNullable(recipientEntity.getAddressDetails().getStreet()).orElseThrow(createInternalServerErrorProblem(ERROR_RECIPIENT_STREET_ADDRESS_NOT_PRESENT)))
+			.withZipCodeAndCity(ofNullable(extractZipCodeAndCity(recipientEntity.getAddressDetails())).orElseThrow(createInternalServerErrorProblem(ERROR_RECIPIENT_ZIPCODE_OR_CITY_NOT_PRESENT)))
+			.withCounterpart(ofNullable(extractCounterpart(billingRecordEntity.getInvoice())).orElseThrow(createInternalServerErrorProblem(ERROR_RECIPIENT_COUNTERPART_NOT_PRESENT)));
 	}
 
 	/**
@@ -94,12 +94,12 @@ public class ExternalInvoiceMapper {
 	 * @throws ThrowableProblem if any mandatory data is missing
 	 */
 	public static InvoiceHeaderRow toInvoiceHeader(String legalId, BillingRecordEntity billingRecordEntity) {
-		final var invoiceEntity = ofNullable(billingRecordEntity.getInvoice()).orElseThrow(createProblem(ERROR_INVOICE_NOT_PRESENT));
+		final var invoiceEntity = ofNullable(billingRecordEntity.getInvoice()).orElseThrow(createInternalServerErrorProblem(ERROR_INVOICE_NOT_PRESENT));
 
 		return InvoiceHeaderRow.create()
-			.withLegalId(ofNullable(legalId).orElseThrow(createProblem(ERROR_LEGALID_NOT_PRESENT)))
+			.withLegalId(ofNullable(legalId).orElseThrow(createInternalServerErrorProblem(ERROR_LEGALID_NOT_PRESENT)))
 			.withDueDate(invoiceEntity.getDueDate())
-			.withCustomerReference(ofNullable(invoiceEntity.getCustomerReference()).orElseThrow(createProblem(ERROR_CUSTOMER_REFERENCE_NOT_PRESENT)))
+			.withCustomerReference(ofNullable(invoiceEntity.getCustomerReference()).orElseThrow(createInternalServerErrorProblem(ERROR_CUSTOMER_REFERENCE_NOT_PRESENT)))
 			.withOurReference(invoiceEntity.getOurReference());
 	}
 
@@ -113,12 +113,12 @@ public class ExternalInvoiceMapper {
 	 */
 	public static InvoiceRow toInvoiceRow(String legalId, InvoiceRowEntity invoiceRowEntity) {
 		return InvoiceRow.create()
-			.withLegalId(ofNullable(legalId).orElseThrow(createProblem(ERROR_LEGALID_NOT_PRESENT)))
+			.withLegalId(ofNullable(legalId).orElseThrow(createInternalServerErrorProblem(ERROR_LEGALID_NOT_PRESENT)))
 			.withCostPerUnit(invoiceRowEntity.getCostPerUnit())
-			.withText(ofNullable(extractDescription(invoiceRowEntity)).orElseThrow(createProblem(ERROR_DESCRIPTION_NOT_PRESENT)))
+			.withText(ofNullable(extractDescription(invoiceRowEntity)).orElseThrow(createInternalServerErrorProblem(ERROR_DESCRIPTION_NOT_PRESENT)))
 			.withQuantity(ofNullable(invoiceRowEntity.getQuantity()).map(Integer::floatValue).orElse(null))
 			.withTotalAmount(invoiceRowEntity.getTotalAmount())
-			.withVatCode(ofNullable(invoiceRowEntity.getVatCode()).orElseThrow(createProblem(ERROR_VAT_CODE_NOT_PRESENT)));
+			.withVatCode(ofNullable(invoiceRowEntity.getVatCode()).orElseThrow(createInternalServerErrorProblem(ERROR_VAT_CODE_NOT_PRESENT)));
 	}
 
 	/**
@@ -145,15 +145,15 @@ public class ExternalInvoiceMapper {
 	 * @throws ThrowableProblem if any mandatory data is missing
 	 */
 	public static InvoiceAccountingRow toInvoiceAccountingRow(InvoiceRowEntity invoiceRowEntity) {
-		final var accountInformationEmbeddable = ofNullable(invoiceRowEntity.getAccountInformation()).orElseThrow(createProblem(ERROR_ACCOUNT_INFORMATION_NOT_PRESENT));
+		final var accountInformationEmbeddable = ofNullable(invoiceRowEntity.getAccountInformation()).orElseThrow(createInternalServerErrorProblem(ERROR_ACCOUNT_INFORMATION_NOT_PRESENT));
 		return InvoiceAccountingRow.create()
-			.withCostCenter(ofNullable(accountInformationEmbeddable.getCostCenter()).orElseThrow(createProblem(ERROR_COSTCENTER_NOT_PRESENT)))
-			.withSubAccount(ofNullable(accountInformationEmbeddable.getSubaccount()).orElseThrow(createProblem(ERROR_SUBACCOUNT_NOT_PRESENT)))
-			.withOperation(ofNullable(accountInformationEmbeddable.getDepartment()).orElseThrow(createProblem(ERROR_OPERATION_NOT_PRESENT)))
+			.withCostCenter(ofNullable(accountInformationEmbeddable.getCostCenter()).orElseThrow(createInternalServerErrorProblem(ERROR_COSTCENTER_NOT_PRESENT)))
+			.withSubAccount(ofNullable(accountInformationEmbeddable.getSubaccount()).orElseThrow(createInternalServerErrorProblem(ERROR_SUBACCOUNT_NOT_PRESENT)))
+			.withOperation(ofNullable(accountInformationEmbeddable.getDepartment()).orElseThrow(createInternalServerErrorProblem(ERROR_OPERATION_NOT_PRESENT)))
 			.withActivity(accountInformationEmbeddable.getActivity())
 			.withProject(accountInformationEmbeddable.getProject())
 			.withObject(accountInformationEmbeddable.getArticle())
-			.withCounterpart(ofNullable(accountInformationEmbeddable.getCounterpart()).orElseThrow(createProblem(ERROR_COUNTERPART_NOT_PRESENT)))
+			.withCounterpart(ofNullable(accountInformationEmbeddable.getCounterpart()).orElseThrow(createInternalServerErrorProblem(ERROR_COUNTERPART_NOT_PRESENT)))
 			.withTotalAmount(invoiceRowEntity.getTotalAmount())
 			.withAccuralKey(accountInformationEmbeddable.getAccuralKey());
 	}
@@ -166,7 +166,7 @@ public class ExternalInvoiceMapper {
 	 * @throws ThrowableProblem if any mandatory data is missing
 	 */
 	public static InvoiceFooterRow toInvoiceFooter(BillingRecordEntity billingRecordEntity) {
-		final var invoiceEntity = ofNullable(billingRecordEntity.getInvoice()).orElseThrow(createProblem(ERROR_INVOICE_NOT_PRESENT));
+		final var invoiceEntity = ofNullable(billingRecordEntity.getInvoice()).orElseThrow(createInternalServerErrorProblem(ERROR_INVOICE_NOT_PRESENT));
 
 		return InvoiceFooterRow.create()
 			.withTotalAmount(invoiceEntity.getTotalAmount());

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/mapper/InternalInvoiceMapper.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/mapper/InternalInvoiceMapper.java
@@ -14,7 +14,7 @@ import static se.sundsvall.billingpreprocessor.Constants.ERROR_OUR_REFERENCE_NOT
 import static se.sundsvall.billingpreprocessor.Constants.ERROR_SUBACCOUNT_NOT_PRESENT;
 import static se.sundsvall.billingpreprocessor.Constants.ERROR_TOTAL_AMOUNT_NOT_PRESENT;
 import static se.sundsvall.billingpreprocessor.integration.db.model.enums.DescriptionType.STANDARD;
-import static se.sundsvall.billingpreprocessor.service.util.ProblemUtil.createProblem;
+import static se.sundsvall.billingpreprocessor.service.util.ProblemUtil.createInternalServerErrorProblem;
 
 import org.apache.commons.lang3.StringUtils;
 import org.zalando.problem.ThrowableProblem;
@@ -49,14 +49,14 @@ public class InternalInvoiceMapper {
 	 * @throws ThrowableProblem if any mandatory data is missing
 	 */
 	public static InvoiceHeaderRow toInvoiceHeader(BillingRecordEntity billingRecordEntity) {
-		final var invoiceEntity = ofNullable(billingRecordEntity.getInvoice()).orElseThrow(createProblem(ERROR_INVOICE_NOT_PRESENT));
+		final var invoiceEntity = ofNullable(billingRecordEntity.getInvoice()).orElseThrow(createInternalServerErrorProblem(ERROR_INVOICE_NOT_PRESENT));
 
 		return InvoiceHeaderRow.create()
-			.withCustomerId(ofNullable(invoiceEntity.getCustomerId()).orElseThrow(createProblem(ERROR_CUSTOMER_ID_NOT_PRESENT)))
+			.withCustomerId(ofNullable(invoiceEntity.getCustomerId()).orElseThrow(createInternalServerErrorProblem(ERROR_CUSTOMER_ID_NOT_PRESENT)))
 			.withDate(invoiceEntity.getDate())
 			.withDueDate(invoiceEntity.getDueDate())
-			.withCustomerReference(ofNullable(invoiceEntity.getCustomerReference()).orElseThrow(createProblem(ERROR_CUSTOMER_REFERENCE_NOT_PRESENT)))
-			.withOurReference(ofNullable(invoiceEntity.getOurReference()).orElseThrow(createProblem(ERROR_OUR_REFERENCE_NOT_PRESENT)));
+			.withCustomerReference(ofNullable(invoiceEntity.getCustomerReference()).orElseThrow(createInternalServerErrorProblem(ERROR_CUSTOMER_REFERENCE_NOT_PRESENT)))
+			.withOurReference(ofNullable(invoiceEntity.getOurReference()).orElseThrow(createInternalServerErrorProblem(ERROR_OUR_REFERENCE_NOT_PRESENT)));
 	}
 
 	/**
@@ -67,7 +67,7 @@ public class InternalInvoiceMapper {
 	 * @throws ThrowableProblem if any mandatory data is missing
 	 */
 	public static InvoiceDescriptionRow toInvoiceDescriptionRow(BillingRecordEntity billingRecordEntity) {
-		final var invoiceEntity = ofNullable(billingRecordEntity.getInvoice()).orElseThrow(createProblem(ERROR_INVOICE_NOT_PRESENT));
+		final var invoiceEntity = ofNullable(billingRecordEntity.getInvoice()).orElseThrow(createInternalServerErrorProblem(ERROR_INVOICE_NOT_PRESENT));
 
 		return InvoiceDescriptionRow.create()
 			.withDescription(invoiceEntity.getDescription());
@@ -82,10 +82,10 @@ public class InternalInvoiceMapper {
 	 */
 	public static InvoiceRow toInvoiceRow(InvoiceRowEntity invoiceRowEntity) {
 		return InvoiceRow.create()
-			.withDescription(ofNullable(extractDescription(invoiceRowEntity)).orElseThrow(createProblem(ERROR_DESCRIPTION_NOT_PRESENT)))
+			.withDescription(ofNullable(extractDescription(invoiceRowEntity)).orElseThrow(createInternalServerErrorProblem(ERROR_DESCRIPTION_NOT_PRESENT)))
 			.withCostPerUnit(invoiceRowEntity.getCostPerUnit())
 			.withQuantity(ofNullable(invoiceRowEntity.getQuantity()).map(Integer::floatValue).orElse(null))
-			.withTotalAmount(ofNullable(invoiceRowEntity.getTotalAmount()).orElseThrow(createProblem(ERROR_TOTAL_AMOUNT_NOT_PRESENT)));
+			.withTotalAmount(ofNullable(invoiceRowEntity.getTotalAmount()).orElseThrow(createInternalServerErrorProblem(ERROR_TOTAL_AMOUNT_NOT_PRESENT)));
 	}
 
 	/**
@@ -96,16 +96,16 @@ public class InternalInvoiceMapper {
 	 * @throws ThrowableProblem if any mandatory data is missing
 	 */
 	public static InvoiceAccountingRow toInvoiceAccountingRow(InvoiceRowEntity invoiceRowEntity) {
-		final var accountInformationEmbeddable = ofNullable(invoiceRowEntity.getAccountInformation()).orElseThrow(createProblem(ERROR_ACCOUNT_INFORMATION_NOT_PRESENT));
+		final var accountInformationEmbeddable = ofNullable(invoiceRowEntity.getAccountInformation()).orElseThrow(createInternalServerErrorProblem(ERROR_ACCOUNT_INFORMATION_NOT_PRESENT));
 
 		return InvoiceAccountingRow.create()
-			.withCostCenter(ofNullable(accountInformationEmbeddable.getCostCenter()).orElseThrow(createProblem(ERROR_COSTCENTER_NOT_PRESENT)))
-			.withSubAccount(ofNullable(accountInformationEmbeddable.getSubaccount()).orElseThrow(createProblem(ERROR_SUBACCOUNT_NOT_PRESENT)))
-			.withDepartment(ofNullable(accountInformationEmbeddable.getDepartment()).orElseThrow(createProblem(ERROR_DEPARTMENT_NOT_PRESENT)))
+			.withCostCenter(ofNullable(accountInformationEmbeddable.getCostCenter()).orElseThrow(createInternalServerErrorProblem(ERROR_COSTCENTER_NOT_PRESENT)))
+			.withSubAccount(ofNullable(accountInformationEmbeddable.getSubaccount()).orElseThrow(createInternalServerErrorProblem(ERROR_SUBACCOUNT_NOT_PRESENT)))
+			.withDepartment(ofNullable(accountInformationEmbeddable.getDepartment()).orElseThrow(createInternalServerErrorProblem(ERROR_DEPARTMENT_NOT_PRESENT)))
 			.withActivity(accountInformationEmbeddable.getActivity())
 			.withProject(accountInformationEmbeddable.getProject())
 			.withObject(accountInformationEmbeddable.getArticle())
-			.withCounterpart(ofNullable(accountInformationEmbeddable.getCounterpart()).orElseThrow(createProblem(ERROR_COUNTERPART_NOT_PRESENT)))
+			.withCounterpart(ofNullable(accountInformationEmbeddable.getCounterpart()).orElseThrow(createInternalServerErrorProblem(ERROR_COUNTERPART_NOT_PRESENT)))
 			.withTotalAmount(invoiceRowEntity.getTotalAmount())
 			.withAccuralKey(accountInformationEmbeddable.getAccuralKey());
 	}
@@ -116,7 +116,7 @@ public class InternalInvoiceMapper {
 	 * @return
 	 */
 	public static InvoiceFooterRow toInvoiceFooter(BillingRecordEntity billingRecordEntity) {
-		final var invoiceEntity = ofNullable(billingRecordEntity.getInvoice()).orElseThrow(createProblem(ERROR_INVOICE_NOT_PRESENT));
+		final var invoiceEntity = ofNullable(billingRecordEntity.getInvoice()).orElseThrow(createInternalServerErrorProblem(ERROR_INVOICE_NOT_PRESENT));
 
 		return InvoiceFooterRow.create()
 			.withTotalAmount(invoiceEntity.getTotalAmount());

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/util/ProblemUtil.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/util/ProblemUtil.java
@@ -5,12 +5,17 @@ import static org.zalando.problem.Status.INTERNAL_SERVER_ERROR;
 import java.util.function.Supplier;
 
 import org.zalando.problem.Problem;
+import org.zalando.problem.Status;
 import org.zalando.problem.ThrowableProblem;
 
 public class ProblemUtil {
 	private ProblemUtil() {}
 
-	public static Supplier<ThrowableProblem> createProblem(String message) {
-		return () -> Problem.valueOf(INTERNAL_SERVER_ERROR, message);
+	public static Supplier<ThrowableProblem> createInternalServerErrorProblem(String message) {
+		return createProblem(INTERNAL_SERVER_ERROR, message);
+	}
+
+	public static Supplier<ThrowableProblem> createProblem(Status status, String message) {
+		return () -> Problem.valueOf(status, message);
 	}
 }

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/util/StringUtil.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/util/StringUtil.java
@@ -1,13 +1,24 @@
 package se.sundsvall.billingpreprocessor.service.util;
 
 import static java.util.Optional.ofNullable;
+
+import org.apache.commons.lang3.StringUtils;
 public class StringUtil {
 	private StringUtil() {}
 
-	public static String removeHyphensFromNumericString(String value) {
+	public static String formatLegalId(String value) {
+		return ofNullable(value)
+			.map(StringUtil::removeHyphensFromNumericString)
+			.map(String::trim)
+			.map(s -> StringUtils.right(s, 10)) // Trim away century part
+			.orElse(value);
+
+	}
+
+	private static String removeHyphensFromNumericString(String value) {
 		return ofNullable(value)
 			.filter(s -> s.matches("[0-9-]+"))
 			.map(s -> s.replaceAll("\\D", "")) // Replace all non digits with emtpy string
-			.orElse(value);
+			.orElse(null);
 	}
 }

--- a/src/main/resources/application-it.yml
+++ b/src/main/resources/application-it.yml
@@ -12,10 +12,17 @@ spring:
             database:
               action: validate
 
+  security:
+    oauth2:
+      client:
+        registration:
+          party:
+            client-id: someClientId
+            client-secret: someClientSecret
+        provider:
+          party:
+            token-uri: http://localhost:${wiremock.server.port}/token
+
 integration:
   party:
     url: http://localhost:${wiremock.server.port}/party
-    oauth2:
-      token-uri: http://localhost:${wiremock.server.port}/token
-      client-id: someClientId
-      client-secret: someClientSecret

--- a/src/main/resources/application-junit.yml
+++ b/src/main/resources/application-junit.yml
@@ -20,12 +20,19 @@ spring:
               action: create
               create-target: target/database/generated-schema.sql
 
+  security:
+    oauth2:
+      client:
+        registration:
+          party:
+            client-id: someClientId
+            client-secret: someClientSecret
+        provider:
+          party:
+            token-uri: http://someTokenUri
+
 integration:
   party:
-    url: someUrl
-    oauth2:
-      token-uri: someTokenUri
-      client-id: someClientId
-      client-secret: someClientSecret
+    url: http://someUrl
     connect-timeout: 11
     read-timeout: 22

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,9 @@ spring:
           schema-generation:
             database:
               action: none
+  security:
+    oauth2:
+      client:
+        registration:
+          party:
+            authorization-grant-type: client_credentials

--- a/src/test/java/se/sundsvall/billingpreprocessor/integration/party/PartyConfigurationTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/integration/party/PartyConfigurationTest.java
@@ -2,75 +2,70 @@ package se.sundsvall.billingpreprocessor.integration.party;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.times;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static se.sundsvall.billingpreprocessor.integration.party.PartyConfiguration.CLIENT_ID;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cloud.openfeign.FeignBuilderCustomizer;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 
 import se.sundsvall.dept44.configuration.feign.FeignMultiCustomizer;
 import se.sundsvall.dept44.configuration.feign.decoder.ProblemErrorDecoder;
 
-import feign.codec.ErrorDecoder;
-
 @ExtendWith(MockitoExtension.class)
 class PartyConfigurationTest {
 
-    @Mock
-    private PartyProperties.Oauth2 oauth2Mock;
-    @Mock
-    private PartyProperties partyPropertiesMock;
+	@Mock
+	private ClientRegistrationRepository clientRegistrationRepositoryMock;
 
-    @Spy
-    private FeignMultiCustomizer feignMultiCustomizerSpy;
-    @Captor
-    private ArgumentCaptor<ErrorDecoder> errorDecoderCaptor;
+	@Mock
+	private ClientRegistration clientRegistrationMock;
 
-    private final PartyConfiguration configuration = new PartyConfiguration();
+	@Spy
+	private FeignMultiCustomizer feignMultiCustomizerSpy;
 
-    @BeforeEach
-    void setUp() {
-        when(oauth2Mock.tokenUri()).thenReturn("someTokenUri");
-        when(oauth2Mock.clientId()).thenReturn("someClientId");
-        when(oauth2Mock.clientSecret()).thenReturn("someClientSecret");
-        when(partyPropertiesMock.oauth2()).thenReturn(oauth2Mock);
-        when(partyPropertiesMock.connectTimeout()).thenReturn(123);
-        when(partyPropertiesMock.readTimeout()).thenReturn(456);
-    }
+	@Mock
+	private FeignBuilderCustomizer feignBuilderCustomizerMock;
 
-    @Test
-    void testFeignBuilderCustomizer() {
-        try (var mockFeignMultiCustomizer = mockStatic(FeignMultiCustomizer.class)) {
-            mockFeignMultiCustomizer.when(FeignMultiCustomizer::create).thenReturn(feignMultiCustomizerSpy);
+	@Mock
+	private PartyProperties propertiesMock;
 
-            configuration.feignBuilderCustomizer(partyPropertiesMock);
+	@Test
+	void testFeignBuilderCustomizer() {
+		final var configuration = new PartyConfiguration();
 
-            mockFeignMultiCustomizer.verify(FeignMultiCustomizer::create);
-        }
+		when(clientRegistrationRepositoryMock.findByRegistrationId(any())).thenReturn(clientRegistrationMock);
+		when(propertiesMock.connectTimeout()).thenReturn(1);
+		when(propertiesMock.readTimeout()).thenReturn(2);
+		when(feignMultiCustomizerSpy.composeCustomizersToOne()).thenReturn(feignBuilderCustomizerMock);
 
-        verify(oauth2Mock).tokenUri();
-        verify(oauth2Mock).clientId();
-        verify(oauth2Mock).clientSecret();
-        verify(partyPropertiesMock, times(3)).oauth2();
-        verify(partyPropertiesMock).connectTimeout();
-        verify(partyPropertiesMock).readTimeout();
-        verify(feignMultiCustomizerSpy).withErrorDecoder(errorDecoderCaptor.capture());
-        verify(feignMultiCustomizerSpy).withRequestTimeoutsInSeconds(partyPropertiesMock.connectTimeout(), partyPropertiesMock.readTimeout());
-        verify(feignMultiCustomizerSpy).withRetryableOAuth2InterceptorForClientRegistration(any(ClientRegistration.class));
-        verify(feignMultiCustomizerSpy).composeCustomizersToOne();
+		try (MockedStatic<FeignMultiCustomizer> feignMultiCustomizerMock = Mockito.mockStatic(FeignMultiCustomizer.class)) {
+			feignMultiCustomizerMock.when(FeignMultiCustomizer::create).thenReturn(feignMultiCustomizerSpy);
 
-        assertThat(errorDecoderCaptor.getValue())
-            .isInstanceOf(ProblemErrorDecoder.class)
-            .hasFieldOrPropertyWithValue("integrationName", CLIENT_ID);
-    }
+			var customizer = configuration.feignBuilderCustomizer(propertiesMock, clientRegistrationRepositoryMock);
+
+			ArgumentCaptor<ProblemErrorDecoder> errorDecoderCaptor = ArgumentCaptor.forClass(ProblemErrorDecoder.class);
+
+			verify(feignMultiCustomizerSpy).withErrorDecoder(errorDecoderCaptor.capture());
+			verify(clientRegistrationRepositoryMock).findByRegistrationId(CLIENT_ID);
+			verify(feignMultiCustomizerSpy).withRetryableOAuth2InterceptorForClientRegistration(same(clientRegistrationMock));
+			verify(propertiesMock).connectTimeout();
+			verify(propertiesMock).readTimeout();
+			verify(feignMultiCustomizerSpy).withRequestTimeoutsInSeconds(1, 2);
+			verify(feignMultiCustomizerSpy).composeCustomizersToOne();
+
+			assertThat(errorDecoderCaptor.getValue()).hasFieldOrPropertyWithValue("integrationName", CLIENT_ID);
+			assertThat(customizer).isSameAs(feignBuilderCustomizerMock);
+		}
+	}
 }

--- a/src/test/java/se/sundsvall/billingpreprocessor/service/creator/LegalIdProviderTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/service/creator/LegalIdProviderTest.java
@@ -1,0 +1,81 @@
+package se.sundsvall.billingpreprocessor.service.creator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.zalando.problem.Status.INTERNAL_SERVER_ERROR;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.zalando.problem.ThrowableProblem;
+
+import generated.se.sundsvall.party.PartyType;
+import se.sundsvall.billingpreprocessor.integration.party.PartyClient;
+
+@ExtendWith(MockitoExtension.class)
+class LegalIdProviderTest {
+
+	@Mock
+	private PartyClient partyClientMock;
+
+	@InjectMocks
+	private LegalIdProvider legalIdProvider;
+
+	@Captor
+	private ArgumentCaptor<PartyType> partyTypeCaptor;
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	@ValueSource(strings = " ")
+	void translateToLegalIdWithEmptyValue(String value) {
+		final var e = assertThrows(ThrowableProblem.class, () -> legalIdProvider.translateToLegalId(value));
+
+		assertThat(e.getStatus()).isEqualTo(INTERNAL_SERVER_ERROR);
+		assertThat(e.getMessage()).isEqualTo("Internal Server Error: Party id is not present");
+		verifyNoInteractions(partyClientMock);
+	}
+
+	@Test
+	void translatePrivatePartyIdToLegalId() {
+		final var partyId = UUID.randomUUID().toString();
+		final var legalId = "123456789012";
+		when(partyClientMock.getLegalId(PartyType.PRIVATE, partyId)).thenReturn(Optional.of(legalId));
+
+		final var result = legalIdProvider.translateToLegalId(partyId);
+
+		verify(partyClientMock).getLegalId(PartyType.PRIVATE, partyId);
+		verifyNoMoreInteractions(partyClientMock);
+		assertThat(result).isEqualTo(legalId);
+	}
+
+	@Test
+	void translateEnterprisePartyIdToLegalId() {
+		final var partyId = UUID.randomUUID().toString();
+		final var legalId = "123456789012";
+		when(partyClientMock.getLegalId(PartyType.PRIVATE, partyId)).thenReturn(Optional.empty());
+		when(partyClientMock.getLegalId(PartyType.ENTERPRISE, partyId)).thenReturn(Optional.of(legalId));
+
+		final var result = legalIdProvider.translateToLegalId(partyId);
+
+		verify(partyClientMock, times(2)).getLegalId(partyTypeCaptor.capture(), eq(partyId));
+		verifyNoMoreInteractions(partyClientMock);
+		assertThat(result).isEqualTo(legalId);
+		assertThat(partyTypeCaptor.getAllValues()).hasSize(2).containsExactlyInAnyOrder(PartyType.ENTERPRISE, PartyType.PRIVATE);
+	}
+}

--- a/src/test/java/se/sundsvall/billingpreprocessor/service/util/ProblemUtilTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/service/util/ProblemUtilTest.java
@@ -1,6 +1,7 @@
 package se.sundsvall.billingpreprocessor.service.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static se.sundsvall.billingpreprocessor.service.util.ProblemUtil.createInternalServerErrorProblem;
 import static se.sundsvall.billingpreprocessor.service.util.ProblemUtil.createProblem;
 
 import org.apache.commons.lang3.RandomStringUtils;
@@ -10,12 +11,23 @@ import org.zalando.problem.Status;
 class ProblemUtilTest {
 
 	@Test
-	void testCreateProblem() {
+	void testCreateInternalServerErrorProblem() {
 		final var message = RandomStringUtils.randomAlphabetic(10);
-		final var problem = createProblem(message).get();
+		final var problem = createInternalServerErrorProblem(message).get();
 
 		assertThat(problem).isNotNull();
 		assertThat(problem.getStatus()).isEqualTo(Status.INTERNAL_SERVER_ERROR);
 		assertThat(problem.getMessage()).isEqualTo("Internal Server Error: %s".formatted(message));
+	}
+
+	@Test
+	void testCreateProblem() {
+		final var status = Status.I_AM_A_TEAPOT;
+		final var message = RandomStringUtils.randomAlphabetic(10);
+		final var problem = createProblem(status, message).get();
+
+		assertThat(problem).isNotNull();
+		assertThat(problem.getStatus()).isEqualTo(status);
+		assertThat(problem.getMessage()).isEqualTo("%s: %s".formatted(status.getReasonPhrase(), message));
 	}
 }

--- a/src/test/java/se/sundsvall/billingpreprocessor/service/util/StringUtilTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/service/util/StringUtilTest.java
@@ -13,12 +13,16 @@ class StringUtilTest {
 	@ParameterizedTest
 	@MethodSource("removeHyphenArgumentProvider")
 	void removeHyphen(String input, String expectedResponse) {
-		assertThat(StringUtil.removeHyphensFromNumericString(input)).isEqualTo(expectedResponse);
+		assertThat(StringUtil.formatLegalId(input)).isEqualTo(expectedResponse);
 	}
 
 	private static Stream<Arguments> removeHyphenArgumentProvider() {
 		return Stream.of(
 			Arguments.of(null, null),
+			Arguments.of("123456789012", "3456789012"),
+			Arguments.of("1234567890", "1234567890"),
+			Arguments.of("12345678-9012", "3456789012"),
+			Arguments.of("123456-7890", "1234567890"),
 			Arguments.of("123456", "123456"),
 			Arguments.of("ABCDEF", "ABCDEF"),
 			Arguments.of("1-2-3-4-5-6", "123456"),


### PR DESCRIPTION
- Added integration to party service for fetching legal id
- Extended legalid formatting to return legal id without the century part
- Changed party integration to use property model provided by Spring
- Enabled feign clients for the application