### PR TITLE
UF-7692: Extended service to be able to use different file encodings 

### DIFF
--- a/src/main/java/se/sundsvall/billingpreprocessor/Constants.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/Constants.java
@@ -29,6 +29,8 @@ public final class Constants {
 
 	public static final String ERROR_NO_INVOICE_FILE_CONFIGURATION_FOUND = "No invoice file configuration found by type: '%s' and categoryTag: '%s'";
 	public static final String ERROR_INVOICE_FILE_NAME_GENERATION_FAILURE = "Could not generate filename from template: '%s'";
+	public static final String ERROR_INVOICE_FILE_GENERATION_FAILURE = "%s occurred when generating file content";
+	public static final String ERROR_INVOICE_FILE_TRANSFER_FAILURE = "Could not transfer file with filename: '%s' due to %s";
 
 	public static final String EXTERNAL_INVOICE_TYPE = "Extern debitering";
 	public static final String GENERATING_SYSTEM = "BillingPreProcessor";

--- a/src/main/java/se/sundsvall/billingpreprocessor/integration/db/model/InvoiceFileConfigurationEntity.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/integration/db/model/InvoiceFileConfigurationEntity.java
@@ -28,17 +28,20 @@ public class InvoiceFileConfigurationEntity {
 	@Column(name = "id")
 	private long id;
 
-	@Column(name = "type")
+	@Column(name = "type", nullable = false)
 	private String type;
 
-	@Column(name = "category_tag")
+	@Column(name = "category_tag", nullable = false)
 	private String categoryTag;
 
-	@Column(name = "creator_name")
+	@Column(name = "creator_name", nullable = false)
 	private String creatorName;
 
-	@Column(name = "file_name_pattern")
+	@Column(name = "file_name_pattern", nullable = false)
 	private String fileNamePattern;
+
+	@Column(name = "encoding", nullable = false)
+	private String encoding;
 
 	public static InvoiceFileConfigurationEntity create() {
 		return new InvoiceFileConfigurationEntity();
@@ -104,9 +107,22 @@ public class InvoiceFileConfigurationEntity {
 		return this;
 	}
 
+	public String getEncoding() {
+		return encoding;
+	}
+
+	public void setEncoding(String encoding) {
+		this.encoding = encoding;
+	}
+
+	public InvoiceFileConfigurationEntity withEncoding(String encoding) {
+		this.encoding = encoding;
+		return this;
+	}
+
 	@Override
 	public int hashCode() {
-		return Objects.hash(categoryTag, creatorName, fileNamePattern, id, type);
+		return Objects.hash(categoryTag, creatorName, encoding, fileNamePattern, id, type);
 	}
 
 	@Override
@@ -118,14 +134,15 @@ public class InvoiceFileConfigurationEntity {
 			return false;
 		}
 		InvoiceFileConfigurationEntity other = (InvoiceFileConfigurationEntity) obj;
-		return Objects.equals(categoryTag, other.categoryTag) && Objects.equals(creatorName, other.creatorName) && Objects.equals(fileNamePattern, other.fileNamePattern) && id == other.id && Objects.equals(type, other.type);
+		return Objects.equals(categoryTag, other.categoryTag) && Objects.equals(creatorName, other.creatorName) && Objects.equals(encoding, other.encoding) && Objects.equals(fileNamePattern, other.fileNamePattern) && id == other.id && Objects.equals(
+			type, other.type);
 	}
 
 	@Override
 	public String toString() {
 		StringBuilder builder = new StringBuilder();
 		builder.append("InvoiceFileConfigurationEntity [id=").append(id).append(", type=").append(type).append(", categoryTag=").append(categoryTag).append(", creatorName=").append(creatorName).append(", fileNamePattern=").append(fileNamePattern)
-			.append("]");
+			.append(", encoding=").append(encoding).append("]");
 		return builder.toString();
 	}
 }

--- a/src/main/java/se/sundsvall/billingpreprocessor/integration/db/model/InvoiceFileEntity.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/integration/db/model/InvoiceFileEntity.java
@@ -43,6 +43,9 @@ public class InvoiceFileEntity implements Serializable {
 	@Column(name = "content", length = Length.LONG32)
 	private String content;
 
+	@Column(name = "encoding")
+	private String encoding;
+
 	@Column(name = "status")
 	private InvoiceFileStatus status;
 
@@ -97,6 +100,19 @@ public class InvoiceFileEntity implements Serializable {
 
 	public InvoiceFileEntity withContent(String content) {
 		this.content = content;
+		return this;
+	}
+
+	public String getEncoding() {
+		return encoding;
+	}
+
+	public void setEncoding(String encoding) {
+		this.encoding = encoding;
+	}
+
+	public InvoiceFileEntity withEncoding(String encoding) {
+		this.encoding = encoding;
 		return this;
 	}
 
@@ -160,22 +176,27 @@ public class InvoiceFileEntity implements Serializable {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(content, created, id, name, sent, status, type);
+		return Objects.hash(content, created, encoding, id, name, sent, status, type);
 	}
 
 	@Override
 	public boolean equals(Object obj) {
-		if (this == obj) { return true; }
-		if (!(obj instanceof final InvoiceFileEntity other)) { return false; }
-		return Objects.equals(content, other.content) && Objects.equals(created, other.created) && (id == other.id) && Objects.equals(name, other.name) && Objects.equals(sent, other.sent) && (status == other.status) && Objects.equals(type, other.type);
+		if (this == obj) {
+			return true;
+		}
+		if (!(obj instanceof InvoiceFileEntity)) {
+			return false;
+		}
+		InvoiceFileEntity other = (InvoiceFileEntity) obj;
+		return Objects.equals(content, other.content) && Objects.equals(created, other.created) && Objects.equals(encoding, other.encoding) && id == other.id && Objects.equals(name, other.name) && Objects.equals(sent, other.sent)
+			&& status == other.status && Objects.equals(type, other.type);
 	}
 
 	@Override
 	public String toString() {
-		final StringBuilder builder = new StringBuilder();
-		builder.append("InvoiceFileEntity [id=").append(id).append(", name=").append(name).append(", content=").append(content).append(", status=").append(status).append(", type=").append(type).append(", created=").append(created).append(", sent=").append(
-			sent).append("]");
+		StringBuilder builder = new StringBuilder();
+		builder.append("InvoiceFileEntity [id=").append(id).append(", name=").append(name).append(", content=").append(content).append(", encoding=").append(encoding).append(", status=").append(status).append(", type=").append(type).append(
+			", created=").append(created).append(", sent=").append(sent).append("]");
 		return builder.toString();
 	}
-
 }

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/InvoiceFileConfigurationService.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/InvoiceFileConfigurationService.java
@@ -6,6 +6,7 @@ import static org.zalando.problem.Status.INTERNAL_SERVER_ERROR;
 import static se.sundsvall.billingpreprocessor.Constants.ERROR_INVOICE_FILE_NAME_GENERATION_FAILURE;
 import static se.sundsvall.billingpreprocessor.Constants.ERROR_NO_INVOICE_FILE_CONFIGURATION_FOUND;
 
+import java.nio.charset.Charset;
 import java.text.SimpleDateFormat;
 import java.time.Clock;
 import java.util.Date;
@@ -31,6 +32,10 @@ public class InvoiceFileConfigurationService {
 	public String getInvoiceFileNameBy(String type, String categoryTag) {
 		final var fileNamePattern = getInvoiceFileConfigurationBy(type, categoryTag).getFileNamePattern();
 		return applyDatePattern(fileNamePattern);
+	}
+
+	public Charset getEncoding(String type, String categoryTag) {
+		return Charset.forName(getInvoiceFileConfigurationBy(type, categoryTag).getEncoding());
 	}
 
 	private InvoiceFileConfigurationEntity getInvoiceFileConfigurationBy(String type, String categoryTag) {

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/creator/ExternalInvoiceCreator.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/creator/ExternalInvoiceCreator.java
@@ -72,7 +72,7 @@ public class ExternalInvoiceCreator implements InvoiceCreator {
 	/**
 	 * Method creates a file header according to the specification for external invoices
 	 * 
-	 * @return bytearray in US_ASCII format representing the file header
+	 * @return bytearray representing the file header
 	 * @throws IOException if byte array output stream can not be closed
 	 */
 	@Override
@@ -90,7 +90,7 @@ public class ExternalInvoiceCreator implements InvoiceCreator {
 	 * Method creates a invoice data section according to the specification for external invoices
 	 * 
 	 * @param billingRecord containing the billing record to produce a invoice data section for
-	 * @return bytearray in US_ASCII format representing the invoice data section
+	 * @return bytearray representing the invoice data section
 	 * @throws IOException if byte array output stream can not be closed
 	 */
 	@Override

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/creator/ExternalInvoiceCreator.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/creator/ExternalInvoiceCreator.java
@@ -19,6 +19,7 @@ import static se.sundsvall.billingpreprocessor.service.util.StringUtil.formatLeg
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
 
 import org.beanio.BeanWriter;
 import org.beanio.StreamFactory;
@@ -45,16 +46,18 @@ public class ExternalInvoiceCreator implements InvoiceCreator {
 		this.configurationRepository = configurationRepository;
 	}
 
+	private InvoiceFileConfigurationEntity getConfiguration() {
+		return configurationRepository.findByCreatorName(this.getClass().getSimpleName())
+			.orElseThrow(createInternalServerErrorProblem(CONFIGURATION_NOT_PRESENT.formatted(this.getClass().getSimpleName())));
+	}
+
 	/**
 	 * Method returning the type that the creator can handle
 	 * 
 	 * @return the type that the creator can handle
 	 */
 	public Type getProcessableType() {
-		return configurationRepository.findByCreatorName(this.getClass().getSimpleName())
-			.map(InvoiceFileConfigurationEntity::getType)
-			.map(Type::valueOf)
-			.orElseThrow(createInternalServerErrorProblem(CONFIGURATION_NOT_PRESENT.formatted(this.getClass().getSimpleName())));
+		return Type.valueOf(getConfiguration().getType());
 	}
 
 	/**
@@ -63,21 +66,20 @@ public class ExternalInvoiceCreator implements InvoiceCreator {
 	 * @return the category that the creator can handle
 	 */
 	public String getProcessableCategory() {
-		return configurationRepository.findByCreatorName(this.getClass().getSimpleName())
-			.map(InvoiceFileConfigurationEntity::getCategoryTag)
-			.orElseThrow(createInternalServerErrorProblem(CONFIGURATION_NOT_PRESENT.formatted(this.getClass().getSimpleName())));
+		return getConfiguration().getCategoryTag();
 	}
 
 	/**
 	 * Method creates a file header according to the specification for external invoices
 	 * 
-	 * @return bytearray representing the file header
+	 * @return bytearray in US_ASCII format representing the file header
 	 * @throws IOException if byte array output stream can not be closed
 	 */
 	@Override
 	public byte[] createFileHeader() throws IOException {
+		final var encoding = Charset.forName(getConfiguration().getEncoding());
 		try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-			BeanWriter invoiceWriter = factory.createWriter(EXTERNAL_INVOICE_BUILDER, new OutputStreamWriter(byteArrayOutputStream))) {
+			BeanWriter invoiceWriter = factory.createWriter(EXTERNAL_INVOICE_BUILDER, new OutputStreamWriter(byteArrayOutputStream, encoding))) {
 			invoiceWriter.write(toFileHeader(GENERATING_SYSTEM, EXTERNAL_INVOICE_TYPE));
 			invoiceWriter.flush();
 			return byteArrayOutputStream.toByteArray();
@@ -88,7 +90,7 @@ public class ExternalInvoiceCreator implements InvoiceCreator {
 	 * Method creates a invoice data section according to the specification for external invoices
 	 * 
 	 * @param billingRecord containing the billing record to produce a invoice data section for
-	 * @return bytearray representing the invoice data section
+	 * @return bytearray in US_ASCII format representing the invoice data section
 	 * @throws IOException if byte array output stream can not be closed
 	 */
 	@Override
@@ -97,8 +99,9 @@ public class ExternalInvoiceCreator implements InvoiceCreator {
 			return EMPTY_ARRAY;
 		}
 
+		final var encoding = Charset.forName(getConfiguration().getEncoding());
 		try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-			BeanWriter invoiceWriter = factory.createWriter(EXTERNAL_INVOICE_BUILDER, new OutputStreamWriter(byteArrayOutputStream))) {
+			BeanWriter invoiceWriter = factory.createWriter(EXTERNAL_INVOICE_BUILDER, new OutputStreamWriter(byteArrayOutputStream, encoding))) {
 			processInvoice(invoiceWriter, billingRecord);
 			invoiceWriter.flush();
 			return byteArrayOutputStream.toByteArray();

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/creator/InternalInvoiceCreator.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/creator/InternalInvoiceCreator.java
@@ -66,7 +66,7 @@ public class InternalInvoiceCreator implements InvoiceCreator {
 	/**
 	 * Method creates a file header according to the specification for internal invoices
 	 * 
-	 * @return bytearray in US_ASCII format representing the file header
+	 * @return bytearray representing the file header
 	 * @throws IOException if byte array output stream can not be closed
 	 */
 	@Override
@@ -84,7 +84,7 @@ public class InternalInvoiceCreator implements InvoiceCreator {
 	 * Method creates a invoice data section according to the specification for internal invoices
 	 * 
 	 * @param billingRecord containing the billing record to produce a invoice data section for
-	 * @return bytearray in US_ASCII format representing the invoice data section
+	 * @return bytearray representing the invoice data section
 	 * @throws IOException if byte array output stream can not be closed
 	 */
 	@Override

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/creator/InternalInvoiceCreator.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/creator/InternalInvoiceCreator.java
@@ -15,6 +15,7 @@ import static se.sundsvall.billingpreprocessor.service.util.ProblemUtil.createIn
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
 
 import org.beanio.BeanWriter;
 import org.beanio.StreamFactory;
@@ -39,16 +40,18 @@ public class InternalInvoiceCreator implements InvoiceCreator {
 		this.configurationRepository = configurationRepository;
 	}
 
+	private InvoiceFileConfigurationEntity getConfiguration() {
+		return configurationRepository.findByCreatorName(this.getClass().getSimpleName())
+			.orElseThrow(createInternalServerErrorProblem(CONFIGURATION_NOT_PRESENT.formatted(this.getClass().getSimpleName())));
+	}
+
 	/**
 	 * Method returning the type that the creator can handle
 	 * 
 	 * @return the type that the creator can handle
 	 */
 	public Type getProcessableType() {
-		return configurationRepository.findByCreatorName(this.getClass().getSimpleName())
-			.map(InvoiceFileConfigurationEntity::getType)
-			.map(Type::valueOf)
-			.orElseThrow(createInternalServerErrorProblem(CONFIGURATION_NOT_PRESENT.formatted(this.getClass().getSimpleName())));
+		return Type.valueOf(getConfiguration().getType());
 	}
 
 	/**
@@ -57,21 +60,20 @@ public class InternalInvoiceCreator implements InvoiceCreator {
 	 * @return the category that the creator can handle
 	 */
 	public String getProcessableCategory() {
-		return configurationRepository.findByCreatorName(this.getClass().getSimpleName())
-			.map(InvoiceFileConfigurationEntity::getCategoryTag)
-			.orElseThrow(createInternalServerErrorProblem(CONFIGURATION_NOT_PRESENT.formatted(this.getClass().getSimpleName())));
+		return getConfiguration().getCategoryTag();
 	}
 
 	/**
 	 * Method creates a file header according to the specification for internal invoices
 	 * 
-	 * @return bytearray representing the file header
+	 * @return bytearray in US_ASCII format representing the file header
 	 * @throws IOException if byte array output stream can not be closed
 	 */
 	@Override
 	public byte[] createFileHeader() throws IOException {
+		final var encoding = Charset.forName(getConfiguration().getEncoding());
 		try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-			BeanWriter invoiceWriter = factory.createWriter(INTERNAL_INVOICE_BUILDER, new OutputStreamWriter(byteArrayOutputStream))) {
+			BeanWriter invoiceWriter = factory.createWriter(INTERNAL_INVOICE_BUILDER, new OutputStreamWriter(byteArrayOutputStream, encoding))) {
 			invoiceWriter.write(toFileHeader());
 			invoiceWriter.flush();
 			return byteArrayOutputStream.toByteArray();
@@ -82,7 +84,7 @@ public class InternalInvoiceCreator implements InvoiceCreator {
 	 * Method creates a invoice data section according to the specification for internal invoices
 	 * 
 	 * @param billingRecord containing the billing record to produce a invoice data section for
-	 * @return bytearray representing the invoice data section
+	 * @return bytearray in US_ASCII format representing the invoice data section
 	 * @throws IOException if byte array output stream can not be closed
 	 */
 	@Override
@@ -91,8 +93,9 @@ public class InternalInvoiceCreator implements InvoiceCreator {
 			return EMPTY_ARRAY;
 		}
 
+		final var encoding = Charset.forName(getConfiguration().getEncoding());
 		try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-			BeanWriter invoiceWriter = factory.createWriter(INTERNAL_INVOICE_BUILDER, new OutputStreamWriter(byteArrayOutputStream))) {
+			BeanWriter invoiceWriter = factory.createWriter(INTERNAL_INVOICE_BUILDER, new OutputStreamWriter(byteArrayOutputStream, encoding))) {
 			processInvoice(invoiceWriter, billingRecord);
 			invoiceWriter.flush();
 			return byteArrayOutputStream.toByteArray();

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/mapper/InvoiceFileMapper.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/mapper/InvoiceFileMapper.java
@@ -3,7 +3,7 @@ package se.sundsvall.billingpreprocessor.service.mapper;
 import static java.util.Optional.ofNullable;
 import static se.sundsvall.billingpreprocessor.integration.db.model.enums.InvoiceFileStatus.GENERATED;
 
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 
 import se.sundsvall.billingpreprocessor.integration.db.model.InvoiceFileEntity;
 
@@ -11,13 +11,14 @@ public final class InvoiceFileMapper {
 
 	private InvoiceFileMapper() {}
 
-	public static InvoiceFileEntity toInvoiceFileEntity(String name, String type, byte[] content) {
+	public static InvoiceFileEntity toInvoiceFileEntity(String name, String type, byte[] content, Charset fileEncoding) {
 		final var entity = InvoiceFileEntity.create()
 			.withStatus(GENERATED);
 
 		ofNullable(name).ifPresent(entity::setName);
 		ofNullable(type).ifPresent(entity::setType);
-		ofNullable(content).ifPresent(b -> entity.setContent(new String(b, StandardCharsets.UTF_8)));
+		ofNullable(content).ifPresent(b -> entity.setContent(new String(b, fileEncoding)));
+		ofNullable(fileEncoding).ifPresent(encoding -> entity.setEncoding(encoding.name()));
 
 		return entity;
 	}

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/scheduler/InvoiceFileScheduler.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/scheduler/InvoiceFileScheduler.java
@@ -27,22 +27,20 @@ public class InvoiceFileScheduler {
 	@Scheduled(cron = "${scheduler.createfiles.cron}")
 	@SchedulerLock(name = "createfiles", lockAtMostFor = "${scheduler.shedlock-lock-at-most-for}")
 	public void executeCreateFiles() {
-		LOGGER.info(LOG_CREATE_FILES_STARTED);
-
 		RequestId.init();
-		invoiceFileService.createFiles();
 
+		LOGGER.info(LOG_CREATE_FILES_STARTED);
+		invoiceFileService.createFiles();
 		LOGGER.info(LOG_CREATE_FILES_ENDED);
 	}
 
 	@Scheduled(cron = "${scheduler.transferfiles.cron}")
 	@SchedulerLock(name = "transferfiles", lockAtMostFor = "${scheduler.shedlock-lock-at-most-for}")
 	public void executeTransferFiles() {
-		LOGGER.info(LOG_TRANSFER_FILES_STARTED);
-
 		RequestId.init();
-		invoiceFileService.transferFiles();
 
+		LOGGER.info(LOG_TRANSFER_FILES_STARTED);
+		invoiceFileService.transferFiles();
 		LOGGER.info(LOG_TRANSFER_FILES_ENDED);
 	}
 }

--- a/src/main/resources/db/migration/V1_3__extend_tables_with_file_encoding.sql
+++ b/src/main/resources/db/migration/V1_3__extend_tables_with_file_encoding.sql
@@ -1,0 +1,11 @@
+alter table file_configuration
+	add column encoding varchar(255) not null default 'ISO-8859-1';
+    
+alter table file_configuration
+	alter column encoding drop default;
+
+alter table invoice_file
+	add column encoding varchar(255) not null default 'UTF-8';
+
+alter table invoice_file
+	alter column encoding drop default;

--- a/src/test/java/se/sundsvall/billingpreprocessor/integration/db/InvoiceFileConfigurationRepositoryTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/integration/db/InvoiceFileConfigurationRepositoryTest.java
@@ -3,7 +3,12 @@ package se.sundsvall.billingpreprocessor.integration.db;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -31,7 +36,9 @@ class InvoiceFileConfigurationRepositoryTest {
 		final var config = InvoiceFileConfigurationEntity.create()
 			.withType("type")
 			.withCategoryTag("categoryTag")
-			.withFileNamePattern("fileNamePattern");
+			.withFileNamePattern("fileNamePattern")
+			.withCreatorName("creatorName")
+			.withEncoding("encoding");
 
 		final var result = repository.saveAndFlush(config);
 
@@ -40,6 +47,51 @@ class InvoiceFileConfigurationRepositoryTest {
 		assertThat(result.getType()).isEqualTo("type");
 		assertThat(result.getCategoryTag()).isEqualTo("categoryTag");
 		assertThat(result.getFileNamePattern()).isEqualTo("fileNamePattern");
+		assertThat(result.getCreatorName()).isEqualTo("creatorName");
+		assertThat(result.getEncoding()).isEqualTo("encoding");
+	}
+
+	@ParameterizedTest
+	@MethodSource("createFailsDueToNotNullConstraintArgumentProvider")
+	void createFailsDueToNotNullConstraint(InvoiceFileConfigurationEntity config, String expectedErrorMessage) {
+		final var exception = assertThrows(DataIntegrityViolationException.class, () -> repository.save(config));
+
+		assertThat(exception.getMessage()).contains(expectedErrorMessage);
+	}
+
+	private static Stream<Arguments> createFailsDueToNotNullConstraintArgumentProvider() {
+		return Stream.of(
+			Arguments.of(InvoiceFileConfigurationEntity.create()
+				.withCategoryTag("categoryTag")
+				.withFileNamePattern("fileNamePattern")
+				.withCreatorName("creatorName")
+				.withEncoding("encoding"),
+				"Column 'type' cannot be null"),
+			Arguments.of(InvoiceFileConfigurationEntity.create()
+				.withType("type")
+				.withFileNamePattern("fileNamePattern")
+				.withCreatorName("creatorName")
+				.withEncoding("encoding"),
+				"Column 'category_tag' cannot be null"),
+			Arguments.of(InvoiceFileConfigurationEntity.create()
+				.withType("type")
+				.withCategoryTag("categoryTag")
+				.withCreatorName("creatorName")
+				.withEncoding("encoding"),
+				"Column 'file_name_pattern' cannot be null"),
+			Arguments.of(InvoiceFileConfigurationEntity.create()
+				.withType("type")
+				.withCategoryTag("categoryTag")
+				.withFileNamePattern("fileNamePattern")
+				.withEncoding("encoding"),
+				"Column 'creator_name' cannot be null"),
+			Arguments.of(InvoiceFileConfigurationEntity.create()
+				.withType("type")
+				.withCategoryTag("categoryTag")
+				.withFileNamePattern("fileNamePattern")
+				.withCreatorName("creatorName"),
+				"Column 'encoding' cannot be null")
+		);
 	}
 
 	@Test
@@ -48,12 +100,16 @@ class InvoiceFileConfigurationRepositoryTest {
 		final var config1 = InvoiceFileConfigurationEntity.create()
 			.withType("type")
 			.withCategoryTag("categoryTag")
-			.withFileNamePattern("fileNamePattern1");
+			.withFileNamePattern("fileNamePattern")
+			.withCreatorName("creatorName")
+			.withEncoding("encoding");
 
 		final var config2 = InvoiceFileConfigurationEntity.create()
 			.withType("type")
 			.withCategoryTag("categoryTag")
-			.withFileNamePattern("fileNamePattern2");
+			.withFileNamePattern("fileNamePattern")
+			.withCreatorName("creatorName")
+			.withEncoding("encoding");
 
 		repository.save(config1);
 
@@ -74,5 +130,13 @@ class InvoiceFileConfigurationRepositoryTest {
 	@Test
 	void existsByTypeAndCategoryTag() {
 		assertThat(repository.existsByTypeAndCategoryTag("type3", "category_tag3")).isTrue();
+	}
+
+	@Test
+	void findByCreatorName() {
+		final var result = repository.findByCreatorName("creator_name_3").get();
+
+		assertThat(result).isNotNull();
+		assertThat(result.getFileNamePattern()).isEqualTo("file_name_pattern3");
 	}
 }

--- a/src/test/java/se/sundsvall/billingpreprocessor/integration/db/model/InvoiceFileConfigurationEntityTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/integration/db/model/InvoiceFileConfigurationEntityTest.java
@@ -1,15 +1,15 @@
 package se.sundsvall.billingpreprocessor.integration.db.model;
 
-import org.junit.jupiter.api.Test;
-
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanConstructor;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanEquals;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanHashCode;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanToString;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidGettersAndSetters;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
 
 class InvoiceFileConfigurationEntityTest {
 
@@ -25,17 +25,23 @@ class InvoiceFileConfigurationEntityTest {
 
 	@Test
 	void builderMethods() {
-		var type = "type";
-		var categoryTage = "categoryTag";
-		var fileNamePattern = "fileNamePattern";
+		final var categoryTage = "categoryTag";
+		final var creatorName = "creatorName";
+		final var encoding = "encoding";
+		final var fileNamePattern = "fileNamePattern";
+		final var type = "type";
 
-		var result = InvoiceFileConfigurationEntity.create()
-			.withType(type)
+		final var result = InvoiceFileConfigurationEntity.create()
 			.withCategoryTag(categoryTage)
-			.withFileNamePattern(fileNamePattern);
+			.withCreatorName(creatorName)
+			.withEncoding(encoding)
+			.withFileNamePattern(fileNamePattern)
+			.withType(type);
 
-		assertThat(result.getType()).isEqualTo(type);
 		assertThat(result.getCategoryTag()).isEqualTo(categoryTage);
+		assertThat(result.getCreatorName()).isEqualTo(creatorName);
+		assertThat(result.getEncoding()).isEqualTo(encoding);
 		assertThat(result.getFileNamePattern()).isEqualTo(fileNamePattern);
+		assertThat(result.getType()).isEqualTo(type);
 	}
 }

--- a/src/test/java/se/sundsvall/billingpreprocessor/integration/db/model/InvoiceFileEntityTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/integration/db/model/InvoiceFileEntityTest.java
@@ -41,6 +41,7 @@ class InvoiceFileEntityTest {
 		BillingRecordEntity.create();
 		final var content = "content";
 		final var created = OffsetDateTime.now();
+		final var encoding = "encoding";
 		final var id = 1;
 		final var name = "name";
 		final var sent = OffsetDateTime.now();
@@ -50,6 +51,7 @@ class InvoiceFileEntityTest {
 		final var entity = InvoiceFileEntity.create()
 			.withContent(content)
 			.withCreated(created)
+			.withEncoding(encoding)
 			.withId(id)
 			.withName(name)
 			.withSent(sent)
@@ -59,6 +61,7 @@ class InvoiceFileEntityTest {
 		assertThat(entity).hasNoNullFieldsOrProperties();
 		assertThat(entity.getContent()).isEqualTo(content);
 		assertThat(entity.getCreated()).isEqualTo(created);
+		assertThat(entity.getEncoding()).isEqualTo(encoding);
 		assertThat(entity.getId()).isEqualTo(id);
 		assertThat(entity.getName()).isEqualTo(name);
 		assertThat(entity.getSent()).isEqualTo(sent);

--- a/src/test/java/se/sundsvall/billingpreprocessor/service/creator/ExternalInvoiceCreatorTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/service/creator/ExternalInvoiceCreatorTest.java
@@ -146,11 +146,14 @@ class ExternalInvoiceCreatorTest {
 
 	@Test
 	void createFileHeader() throws Exception {
+		final var config = InvoiceFileConfigurationEntity.create().withEncoding(StandardCharsets.ISO_8859_1.name());
+		when(invoiceFileConfigurationRepositoryMock.findByCreatorName("ExternalInvoiceCreator")).thenReturn(Optional.of(config));
+
 		final var result = creator.createFileHeader();
 		final var expected = getResource("validation/external_header_expected_format.txt")
 			.replace("yyMMdd", LocalDate.now().format(DateTimeFormatter.ofPattern("yyMMdd")));
 
-		assertThat(new String(result, StandardCharsets.UTF_8)).isEqualTo(expected);
+		assertThat(new String(result, StandardCharsets.ISO_8859_1)).isEqualTo(expected);
 	}
 
 	@Test
@@ -160,6 +163,9 @@ class ExternalInvoiceCreatorTest {
 
 	@Test
 	void createInvoiceDataWhenInvoiceMissing() throws Exception {
+		final var config = InvoiceFileConfigurationEntity.create().withEncoding(StandardCharsets.ISO_8859_1.name());
+		when(invoiceFileConfigurationRepositoryMock.findByCreatorName("ExternalInvoiceCreator")).thenReturn(Optional.of(config));
+
 		final var input = createbillingRecordEntity().withInvoice(null);
 		final var e = assertThrows(ThrowableProblem.class, () -> creator.createInvoiceData(input));
 
@@ -169,15 +175,21 @@ class ExternalInvoiceCreatorTest {
 
 	@Test
 	void createInvoiceDataFromEntityWithLegalId() throws Exception {
+		final var config = InvoiceFileConfigurationEntity.create().withEncoding(StandardCharsets.ISO_8859_1.name());
+		when(invoiceFileConfigurationRepositoryMock.findByCreatorName("ExternalInvoiceCreator")).thenReturn(Optional.of(config));
+
 		final var result = creator.createInvoiceData(createbillingRecordEntity());
 		final var expected = getResource("validation/external_invoicedata_expected_format.txt");
 
-		assertThat(new String(result, StandardCharsets.UTF_8)).isEqualTo(expected);
+		assertThat(new String(result, StandardCharsets.ISO_8859_1)).isEqualTo(expected);
 		verify(legalIdProviderMock, never()).translateToLegalId(any());
 	}
 
 	@Test
 	void createInvoiceDataFromEntityWithoutLegalId() throws Exception {
+		final var config = InvoiceFileConfigurationEntity.create().withEncoding(StandardCharsets.ISO_8859_1.name());
+		when(invoiceFileConfigurationRepositoryMock.findByCreatorName("ExternalInvoiceCreator")).thenReturn(Optional.of(config));
+
 		final var input = createbillingRecordEntity();
 		input.getRecipient().withLegalId(null).withPartyId(PARTY_ID);
 
@@ -186,7 +198,7 @@ class ExternalInvoiceCreatorTest {
 		final var result = creator.createInvoiceData(input);
 		final var expected = getResource("validation/external_invoicedata_expected_format.txt");
 
-		assertThat(new String(result, StandardCharsets.UTF_8)).isEqualTo(expected);
+		assertThat(new String(result, StandardCharsets.ISO_8859_1)).isEqualTo(expected);
 		verify(legalIdProviderMock).translateToLegalId(PARTY_ID);
 	}
 

--- a/src/test/java/se/sundsvall/billingpreprocessor/service/creator/InternalInvoiceCreatorTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/service/creator/InternalInvoiceCreatorTest.java
@@ -113,10 +113,13 @@ class InternalInvoiceCreatorTest {
 
 	@Test
 	void createFileHeader() throws Exception {
+		final var config = InvoiceFileConfigurationEntity.create().withEncoding(StandardCharsets.ISO_8859_1.name());
+		when(invoiceFileConfigurationRepositoryMock.findByCreatorName("InternalInvoiceCreator")).thenReturn(Optional.of(config));
+
 		final var result = creator.createFileHeader();
 		final var expected = getResource("validation/internal_header_expected_format.txt");
 
-		assertThat(new String(result, StandardCharsets.UTF_8)).isEqualTo(expected);
+		assertThat(new String(result, StandardCharsets.ISO_8859_1)).isEqualTo(expected);
 	}
 
 	@Test
@@ -126,6 +129,9 @@ class InternalInvoiceCreatorTest {
 
 	@Test
 	void createInvoiceDataWhenInvoiceMissing() throws Exception {
+		final var config = InvoiceFileConfigurationEntity.create().withEncoding(StandardCharsets.ISO_8859_1.name());
+		when(invoiceFileConfigurationRepositoryMock.findByCreatorName("InternalInvoiceCreator")).thenReturn(Optional.of(config));
+
 		final var input = createbillingRecordEntity().withInvoice(null);
 		final var e = assertThrows(ThrowableProblem.class, () -> creator.createInvoiceData(input));
 
@@ -135,10 +141,13 @@ class InternalInvoiceCreatorTest {
 
 	@Test
 	void createInvoiceDataFromEntity() throws Exception {
+		final var config = InvoiceFileConfigurationEntity.create().withEncoding(StandardCharsets.ISO_8859_1.name());
+		when(invoiceFileConfigurationRepositoryMock.findByCreatorName("InternalInvoiceCreator")).thenReturn(Optional.of(config));
+
 		final var result = creator.createInvoiceData(createbillingRecordEntity());
 		final var expected = getResource("validation/internal_invoicedata_expected_format.txt");
 
-		assertThat(new String(result, StandardCharsets.UTF_8)).isEqualTo(expected);
+		assertThat(new String(result, StandardCharsets.ISO_8859_1)).isEqualTo(expected);
 	}
 
 	private String getResource(final String fileName) throws IOException, URISyntaxException {

--- a/src/test/java/se/sundsvall/billingpreprocessor/service/mapper/InvoiceFileMapperTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/service/mapper/InvoiceFileMapperTest.java
@@ -3,6 +3,8 @@ package se.sundsvall.billingpreprocessor.service.mapper;
 import static org.assertj.core.api.Assertions.assertThat;
 import static se.sundsvall.billingpreprocessor.integration.db.model.enums.InvoiceFileStatus.GENERATED;
 
+import java.nio.charset.StandardCharsets;
+
 import org.junit.jupiter.api.Test;
 
 class InvoiceFileMapperTest {
@@ -12,12 +14,14 @@ class InvoiceFileMapperTest {
 		final var name = "name";
 		final var type = "type";
 		final var content = "content";
+		final var charset = StandardCharsets.UTF_8;
 
-		final var entity = InvoiceFileMapper.toInvoiceFileEntity(name, type, content.getBytes());
+		final var entity = InvoiceFileMapper.toInvoiceFileEntity(name, type, content.getBytes(), charset);
 
-		assertThat(entity).hasAllNullFieldsOrPropertiesExcept("id", "content", "name", "status", "type");
+		assertThat(entity).hasAllNullFieldsOrPropertiesExcept("id", "content", "name", "status", "type", "encoding");
 		assertThat(entity.getId()).isZero();
 		assertThat(entity.getContent()).isEqualTo(content);
+		assertThat(entity.getEncoding()).isEqualTo(charset.name());
 		assertThat(entity.getName()).isEqualTo(name);
 		assertThat(entity.getStatus()).isEqualTo(GENERATED);
 		assertThat(entity.getType()).isEqualTo(type);
@@ -26,7 +30,7 @@ class InvoiceFileMapperTest {
 	@Test
 	void toInvoiceFileEntityFromNull() {
 
-		final var entity = InvoiceFileMapper.toInvoiceFileEntity(null, null, null);
+		final var entity = InvoiceFileMapper.toInvoiceFileEntity(null, null, null, null);
 
 		assertThat(entity).hasAllNullFieldsOrPropertiesExcept("id", "status");
 		assertThat(entity.getId()).isZero();

--- a/src/test/resources/db/schema/schema.sql
+++ b/src/test/resources/db/schema/schema.sql
@@ -20,12 +20,13 @@
     ) engine=InnoDB;
 
     create table file_configuration (
-            id bigint not null auto_increment,
-            category_tag varchar(255),
-            creator_name varchar(255),
-            file_name_pattern varchar(255),
-            type varchar(255),
-            primary key (id)
+        id bigint not null auto_increment,
+        category_tag varchar(255) not null,
+        creator_name varchar(255) not null,
+        encoding varchar(255) not null,
+        file_name_pattern varchar(255) not null,
+        type varchar(255) not null,
+        primary key (id)
     ) engine=InnoDB;
 
     create table invoice (
@@ -45,6 +46,7 @@
         created datetime(6),
         id bigint not null auto_increment,
         sent datetime(6),
+        encoding varchar(255),
         name varchar(255),
         status varchar(255),
         type varchar(255),
@@ -88,18 +90,18 @@
     create index idx_billing_record_category_status 
        on billing_record (category, status);
 
-    create index idx_file_configuration_type_category_tag
+    create index idx_file_configuration_type_category_tag 
        on file_configuration (type, category_tag);
 
-    create index idx_file_configuration_creator_name
+    create index idx_file_configuration_creator_name 
        on file_configuration (creator_name);
-       
-    alter table if exists file_configuration
+
+    alter table if exists file_configuration 
        add constraint uq_type_category_tag unique (type, category_tag);
 
-    alter table if exists file_configuration
+    alter table if exists file_configuration 
        add constraint uq_creator_name unique (creator_name);
-       
+
     create index idx_invoice_file_status 
        on invoice_file (status);
 

--- a/src/test/resources/db/scripts/testdata-it-add-generated-file-entries.sql
+++ b/src/test/resources/db/scripts/testdata-it-add-generated-file-entries.sql
@@ -1,6 +1,6 @@
 -------------------------------------
 -- Invoice files
 -------------------------------------
-INSERT INTO invoice_file (created, name, status, `type`, content)
-VALUES ('2024-03-21 13:17:00.000', 'EXTERNAL_FILE_20240321.txt', 'GENERATED', 'EXTERNAL', 'External content'),
-       ('2024-03-22 13:37:00.000', 'INTERNAL_FILE_20240322.txt', 'GENERATED', 'INTERNAL', 'Internal content');
+INSERT INTO invoice_file (created, name, status, `type`, content, encoding)
+VALUES ('2024-03-21 13:17:00.000', 'EXTERNAL_FILE_20240321.txt', 'GENERATED', 'EXTERNAL', 'External content', 'ISO-8859-1'),
+       ('2024-03-22 13:37:00.000', 'INTERNAL_FILE_20240322.txt', 'GENERATED', 'INTERNAL', 'Internal content', 'ISO-8859-1');

--- a/src/test/resources/db/scripts/testdata-it.sql
+++ b/src/test/resources/db/scripts/testdata-it.sql
@@ -53,7 +53,7 @@ VALUES	('83e4d599-5b4d-431c-8ebc-81192e9401ee', NULL, 'Louiseville', 'Beachland 
 -------------------------------------
 -- Invoice file configuration
 -------------------------------------
-INSERT INTO file_configuration (`type`,category_tag,file_name_pattern, creator_name) 
+INSERT INTO file_configuration (`type`,category_tag,file_name_pattern, creator_name, encoding) 
 VALUES
-	 ('EXTERNAL','ISYCASE','KRISYCASE_{yyyyMMdd}.txt', 'ExternalInvoiceCreator'),
-	 ('INTERNAL','ISYCASE','IPKISYCASE_{yyyyMMdd}.txt', 'InternalInvoiceCreator');
+	 ('EXTERNAL','ISYCASE','KRISYCASE_{yyyyMMdd}.txt', 'ExternalInvoiceCreator', 'ISO-8859-1'),
+	 ('INTERNAL','ISYCASE','IPKISYCASE_{yyyyMMdd}.txt', 'InternalInvoiceCreator', 'ISO-8859-1');

--- a/src/test/resources/db/scripts/testdata-junit.sql
+++ b/src/test/resources/db/scripts/testdata-junit.sql
@@ -44,20 +44,20 @@ VALUES	('83e4d599-5b4d-431c-8ebc-81192e9401ee', NULL, 'Louiseville', 'Beachland 
 -------------------------------------
 -- Invoice file
 -------------------------------------
-INSERT INTO invoice_file (created, content, sent, name, `type`, status) 
+INSERT INTO invoice_file (created, content, encoding, sent, name, `type`, status) 
 VALUES 
-	('2024-02-26 10:15:00.000000', 'File content', NULL, 'INVOICE_FILE_1.txt', 'INTERNAL', 'GENERATED'),
-	('2024-02-25 09:30:00.000000', 'File content', '2024-02-25 09:35:00.000000', 'INVOICE_FILE_2.txt', 'INTERNAL', 'SEND_SUCCESSFUL'),
-	('2024-02-24 14:45:00.000000', 'File content', NULL, 'INVOICE_FILE_3.txt', 'INTERNAL', 'GENERATED'),
-	('2024-02-23 16:20:00.000000', 'File content', NULL, 'INVOICE_FILE_4.txt', 'INTERNAL', 'SEND_FAILED'),
-	('2024-02-22 11:10:00.000000', 'File content', '2024-02-22 11:15:00.000000', 'INVOICE_FILE_5.txt', 'EXTERNAL', 'SEND_SUCCESSFUL');
+	('2024-02-26 10:15:00.000000', 'File content', 'ISO-8859-1', NULL, 'INVOICE_FILE_1.txt', 'INTERNAL', 'GENERATED'),
+	('2024-02-25 09:30:00.000000', 'File content', 'ISO-8859-1', '2024-02-25 09:35:00.000000', 'INVOICE_FILE_2.txt', 'INTERNAL', 'SEND_SUCCESSFUL'),
+	('2024-02-24 14:45:00.000000', 'File content', 'ISO-8859-1', NULL, 'INVOICE_FILE_3.txt', 'INTERNAL', 'GENERATED'),
+	('2024-02-23 16:20:00.000000', 'File content', 'ISO-8859-1', NULL, 'INVOICE_FILE_4.txt', 'INTERNAL', 'SEND_FAILED'),
+	('2024-02-22 11:10:00.000000', 'File content', 'ISO-8859-1', '2024-02-22 11:15:00.000000', 'INVOICE_FILE_5.txt', 'EXTERNAL', 'SEND_SUCCESSFUL');
 
 
 -------------------------------------
 -- Invoice file configuration
 -------------------------------------
-INSERT INTO file_configuration(type, category_tag, file_name_pattern)
+INSERT INTO file_configuration(type, category_tag, file_name_pattern, encoding, creator_name)
 VALUES
-    ('type1', 'category_tag1', 'file_name_pattern1'),
-    ('type1', 'category_tag2', 'file_name_pattern2'),
-    ('type3', 'category_tag3', 'file_name_pattern3');
+    ('type1', 'category_tag1', 'file_name_pattern1', 'encoding_1', 'creator_name_1'),
+    ('type1', 'category_tag2', 'file_name_pattern2', 'encoding_2', 'creator_name_2'),
+    ('type3', 'category_tag3', 'file_name_pattern3', 'encoding_3', 'creator_name_3');


### PR DESCRIPTION
- Extended file configuration to keep track of which file encoding to use for each file
- Added null constraints to configuration
- Improved error message content with better error texts
- Added date of transmission when file has been successfully sent