### PR TITLE
UF-10800: Added U-row to internal invoices

### DIFF
--- a/src/integration-test/java/se/sundsvall/billingpreprocessor/apptest/BillingRecordsIT.java
+++ b/src/integration-test/java/se/sundsvall/billingpreprocessor/apptest/BillingRecordsIT.java
@@ -15,7 +15,6 @@ import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON_VALUE;
 
-import java.nio.charset.Charset;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -45,7 +44,7 @@ class BillingRecordsIT extends AbstractAppTest {
 	private BillingRecordRepository repository;
 
 	@Test
-	void test01_createBillingRecord() {
+	void test01_createExternalBillingRecord() {
 		setupCall()
 			.withServicePath("/2281/billingrecords")
 			.withHttpMethod(POST)
@@ -139,6 +138,17 @@ class BillingRecordsIT extends AbstractAppTest {
 			.withRequest(REQUEST_FILE)
 			.withExpectedResponseStatus(CREATED)
 			.withExpectedResponseHeader(LOCATION, of("^/2281/billingrecords/$"))
+			.sendRequestAndVerifyResponse();
+	}
+
+	@Test
+	void test09_createInternalBillingRecord() {
+		setupCall()
+			.withServicePath("/2281/billingrecords")
+			.withHttpMethod(POST)
+			.withRequest(REQUEST_FILE)
+			.withExpectedResponseStatus(CREATED)
+			.withExpectedResponseHeader(LOCATION, of("^/2281/billingrecords/(.*)$"))
 			.sendRequestAndVerifyResponse();
 	}
 }

--- a/src/integration-test/resources/BillingRecordsIT/__files/test01_createExternalBillingRecord/request.json
+++ b/src/integration-test/resources/BillingRecordsIT/__files/test01_createExternalBillingRecord/request.json
@@ -11,7 +11,6 @@
 		"userId": "ALI23SNU"
 	},
 	"invoice": {
-		"ourReference": "Harvey Kneeslapper",
 		"customerReference": "Alice Snuffleupagus",
 		"dueDate": "2023-12-24",
 		"customerId": "16",
@@ -32,8 +31,7 @@
 			"descriptions": ["Köp av elektrisk tjänstecykel"],
 			"vatCode": "25",
 			"costPerUnit": 7995
-		}],
-		"referenceId": "19-ALI22SNU"
+		}]
 	},
 	"category": "ISYCASE",
 	"type": "EXTERNAL",

--- a/src/integration-test/resources/BillingRecordsIT/__files/test02_readBillingRecordById/response.json
+++ b/src/integration-test/resources/BillingRecordsIT/__files/test02_readBillingRecordById/response.json
@@ -20,12 +20,12 @@
 				"counterpart": "MAN22VEG",
 				"department": "910300"
 			},
-			"descriptions": [
-				"Ordernummer: ewf-3fee-boe3-74",
+			"detailedDescriptions": [
 				"Beställare: MAN22VEG 4480296",
 				"Användare: Ivan Drago IVA02DRA",
 				"Passerkort med foto"
 			],
+			"descriptions": ["Ordernummer: ewf-3fee-boe3-74"],
 			"costPerUnit": 200
 		}],
 		"referenceId": "IN-1998-1884-42"

--- a/src/integration-test/resources/BillingRecordsIT/__files/test03_readAllBillingRecords/response.json
+++ b/src/integration-test/resources/BillingRecordsIT/__files/test03_readAllBillingRecords/response.json
@@ -36,12 +36,12 @@
 						"counterpart": "MAN22VEG",
 						"department": "910300"
 					},
-					"descriptions": [
-						"Ordernummer: ewf-3fee-boe3-74",
+					"detailedDescriptions": [
 						"Beställare: MAN22VEG 4480296",
 						"Användare: Ivan Drago IVA02DRA",
 						"Passerkort med foto"
 					],
+					"descriptions": ["Ordernummer: ewf-3fee-boe3-74"],
 					"costPerUnit": 200
 				}],
 				"referenceId": "IN-1998-1884-42"
@@ -158,12 +158,12 @@
 						"counterpart": "MIC00GOL",
 						"department": "910300"
 					},
-					"descriptions": [
-						"Ordernummer: azi-330c-3fne-33",
+					"detailedDescriptions": [
 						"Beställare: MIC00GOL 22940338",
 						"Användare: Rocky Balboa ROC01BAL",
 						"Passerkort utan foto"
 					],
+					"descriptions": ["Ordernummer: azi-330c-3fne-33"],
 					"costPerUnit": 150
 				}],
 				"referenceId": "IN-5538-4432-36"

--- a/src/integration-test/resources/BillingRecordsIT/__files/test04_readBillingRecordsByFilter/response.json
+++ b/src/integration-test/resources/BillingRecordsIT/__files/test04_readBillingRecordsByFilter/response.json
@@ -36,12 +36,12 @@
 						"counterpart": "MAN22VEG",
 						"department": "910300"
 					},
-					"descriptions": [
-						"Ordernummer: ewf-3fee-boe3-74",
+					"detailedDescriptions": [
 						"Beställare: MAN22VEG 4480296",
 						"Användare: Ivan Drago IVA02DRA",
 						"Passerkort med foto"
 					],
+					"descriptions": ["Ordernummer: ewf-3fee-boe3-74"],
 					"costPerUnit": 200
 				}],
 				"referenceId": "IN-1998-1884-42"

--- a/src/integration-test/resources/BillingRecordsIT/__files/test09_createInternalBillingRecord/request.json
+++ b/src/integration-test/resources/BillingRecordsIT/__files/test09_createInternalBillingRecord/request.json
@@ -3,7 +3,7 @@
 		"ourReference": "Harvey Kneeslapper",
 		"dueDate": "2023-12-24",
 		"customerId": "16",
-		"description": "Internal errand number: 1234-54321",
+		"description": "R-row 1: Errand number 1234-54321",
 		"invoiceRows": [{
 			"quantity": 1,
 			"accountInformation": {
@@ -16,10 +16,7 @@
 				"U-row A",
 				"U-row B"
 			],
-			"descriptions": [
-				"U-row C",
-				"U-row D"
-			],
+			"descriptions": ["R-row 2"],
 			"costPerUnit": 395
 		}],
 		"referenceId": "19-ALI22SNU"

--- a/src/integration-test/resources/BillingRecordsIT/__files/test09_createInternalBillingRecord/request.json
+++ b/src/integration-test/resources/BillingRecordsIT/__files/test09_createInternalBillingRecord/request.json
@@ -1,0 +1,30 @@
+{
+	"invoice": {
+		"ourReference": "Harvey Kneeslapper",
+		"dueDate": "2023-12-24",
+		"customerId": "16",
+		"description": "Internal errand number: 1234-54321",
+		"invoiceRows": [{
+			"quantity": 1,
+			"accountInformation": {
+				"costCenter": "15800100",
+				"subaccount": "936300",
+				"counterpart": "11830000",
+				"department": "920360"
+			},
+			"detailedDescriptions": [
+				"U-row A",
+				"U-row B"
+			],
+			"descriptions": [
+				"U-row C",
+				"U-row D"
+			],
+			"costPerUnit": 395
+		}],
+		"referenceId": "19-ALI22SNU"
+	},
+	"category": "ISYCASE",
+	"type": "INTERNAL",
+	"status": "NEW"
+}

--- a/src/integration-test/resources/JobsIT/__files/test01_createInvoiceFiles/filecontent/expected_internal_content.txt
+++ b/src/integration-test/resources/JobsIT/__files/test01_createInvoiceFiles/filecontent/expected_internal_content.txt
@@ -2,5 +2,8 @@
 H 15                                   JAN00EDO                                                       MAN22VEG                      
 R Passerkort med foto för Ivan Drago (IVA02DRA)                                                       
 R Ordernummer: ewf-3fee-boe3-74                          1.00       200.00                        200.00
+U Beställare: MAN22VEG 4480296                                                                        
+U Användare: Ivan Drago IVA02DRA                                                                      
+U Passerkort med foto                                                                                 
 K 1620000   936100    910300    5247                          MAN                                               200.00              
 T 200.00         

--- a/src/main/java/se/sundsvall/billingpreprocessor/api/validation/impl/ValidInvoiceConstraintValidator.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/api/validation/impl/ValidInvoiceConstraintValidator.java
@@ -1,23 +1,17 @@
 package se.sundsvall.billingpreprocessor.api.validation.impl;
 
-import jakarta.validation.ConstraintValidator;
-import jakarta.validation.ConstraintValidatorContext;
-import org.springframework.util.ObjectUtils;
-import se.sundsvall.billingpreprocessor.api.model.BillingRecord;
-import se.sundsvall.billingpreprocessor.api.model.Invoice;
-import se.sundsvall.billingpreprocessor.api.model.InvoiceRow;
-import se.sundsvall.billingpreprocessor.api.validation.ValidInvoice;
-
-import java.util.ArrayList;
-import java.util.Optional;
-
 import static java.util.Objects.nonNull;
 import static org.apache.commons.lang3.StringUtils.isNoneBlank;
 import static se.sundsvall.billingpreprocessor.api.model.enums.Type.EXTERNAL;
 import static se.sundsvall.billingpreprocessor.api.model.enums.Type.INTERNAL;
 
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import se.sundsvall.billingpreprocessor.api.model.BillingRecord;
+import se.sundsvall.billingpreprocessor.api.model.Invoice;
+import se.sundsvall.billingpreprocessor.api.validation.ValidInvoice;
+
 public class ValidInvoiceConstraintValidator implements ConstraintValidator<ValidInvoice, BillingRecord> {
-	private static final String CUSTOM_ERROR_MESSAGE_INVOICE_ROW = "can not contain detailed description on invoice rows when billing record is of type " + INTERNAL;
 	private static final String CUSTOM_ERROR_MESSAGE_MISSING_REFERENCE_ID = "invoice.referenceId is mandatory when billing record is of type " + INTERNAL;
 	private static final String CUSTOM_ERROR_MESSAGE_MISSING_OUR_REFERENCE = "invoice.ourReference is mandatory when billing record is of type " + INTERNAL;
 	private static final String CUSTOM_ERROR_MESSAGE_MISSING_CUSTOMER_REFERENCE = "invoice.customerReference is mandatory when billing record is of type " + EXTERNAL;
@@ -35,11 +29,6 @@ public class ValidInvoiceConstraintValidator implements ConstraintValidator<Vali
 
 			if (!isValidOurReference(billingRecord.getInvoice())) {
 				useCustomMessageForValidation(context, CUSTOM_ERROR_MESSAGE_MISSING_OUR_REFERENCE);
-				isValid = false;
-			}
-
-			if (!isValidInvoiceRows(billingRecord.getInvoice())) {
-				useCustomMessageForValidation(context, CUSTOM_ERROR_MESSAGE_INVOICE_ROW);
 				isValid = false;
 			}
 		}
@@ -62,16 +51,6 @@ public class ValidInvoiceConstraintValidator implements ConstraintValidator<Vali
 
 	private boolean isValidOurReference(Invoice invoice) {
 		return isNoneBlank(invoice.getOurReference());
-	}
-
-	private boolean isValidInvoiceRows(Invoice invoice) {
-		// Verify that no detailed description rows exists for any of the provided invoice rows
-		return Optional.ofNullable(invoice)
-			.flatMap(i -> Optional.ofNullable(i.getInvoiceRows()))
-			.orElseGet(ArrayList::new)
-			.stream()
-			.map(InvoiceRow::getDetailedDescriptions)
-			.allMatch(ObjectUtils::isEmpty);
 	}
 
 	private void useCustomMessageForValidation(ConstraintValidatorContext constraintContext, String message) {

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/creator/InternalInvoiceCreator.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/creator/InternalInvoiceCreator.java
@@ -7,6 +7,7 @@ import static se.sundsvall.billingpreprocessor.service.creator.config.InvoiceCre
 import static se.sundsvall.billingpreprocessor.service.mapper.InternalInvoiceMapper.toFileHeader;
 import static se.sundsvall.billingpreprocessor.service.mapper.InternalInvoiceMapper.toInvoiceAccountingRow;
 import static se.sundsvall.billingpreprocessor.service.mapper.InternalInvoiceMapper.toInvoiceDescriptionRow;
+import static se.sundsvall.billingpreprocessor.service.mapper.InternalInvoiceMapper.toInvoiceRowDescriptionRows;
 import static se.sundsvall.billingpreprocessor.service.mapper.InternalInvoiceMapper.toInvoiceFooter;
 import static se.sundsvall.billingpreprocessor.service.mapper.InternalInvoiceMapper.toInvoiceHeader;
 import static se.sundsvall.billingpreprocessor.service.mapper.InternalInvoiceMapper.toInvoiceRow;
@@ -47,33 +48,35 @@ public class InternalInvoiceCreator implements InvoiceCreator {
 
 	/**
 	 * Method returning the type that the creator can handle
-	 * 
+	 *
 	 * @return the type that the creator can handle
 	 */
+	@Override
 	public Type getProcessableType() {
 		return Type.valueOf(getConfiguration().getType());
 	}
 
 	/**
 	 * Method returning the category that the creator can handle
-	 * 
+	 *
 	 * @return the category that the creator can handle
 	 */
+	@Override
 	public String getProcessableCategory() {
 		return getConfiguration().getCategoryTag();
 	}
 
 	/**
 	 * Method creates a file header according to the specification for internal invoices
-	 * 
+	 *
 	 * @return             bytearray representing the file header
 	 * @throws IOException if byte array output stream can not be closed
 	 */
 	@Override
 	public byte[] createFileHeader() throws IOException {
 		final var encoding = Charset.forName(getConfiguration().getEncoding());
-		try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-			BeanWriter invoiceWriter = factory.createWriter(INTERNAL_INVOICE_BUILDER, new OutputStreamWriter(byteArrayOutputStream, encoding))) {
+		try (var byteArrayOutputStream = new ByteArrayOutputStream();
+			var invoiceWriter = factory.createWriter(INTERNAL_INVOICE_BUILDER, new OutputStreamWriter(byteArrayOutputStream, encoding))) {
 			invoiceWriter.write(toFileHeader());
 			invoiceWriter.flush();
 			return byteArrayOutputStream.toByteArray();
@@ -82,7 +85,7 @@ public class InternalInvoiceCreator implements InvoiceCreator {
 
 	/**
 	 * Method creates a invoice data section according to the specification for internal invoices
-	 * 
+	 *
 	 * @param  billingRecord containing the billing record to produce a invoice data section for
 	 * @return               bytearray representing the invoice data section
 	 * @throws IOException   if byte array output stream can not be closed
@@ -94,8 +97,8 @@ public class InternalInvoiceCreator implements InvoiceCreator {
 		}
 
 		final var encoding = Charset.forName(getConfiguration().getEncoding());
-		try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-			BeanWriter invoiceWriter = factory.createWriter(INTERNAL_INVOICE_BUILDER, new OutputStreamWriter(byteArrayOutputStream, encoding))) {
+		try (var byteArrayOutputStream = new ByteArrayOutputStream();
+			var invoiceWriter = factory.createWriter(INTERNAL_INVOICE_BUILDER, new OutputStreamWriter(byteArrayOutputStream, encoding))) {
 			processInvoice(invoiceWriter, billingRecord);
 			invoiceWriter.flush();
 			return byteArrayOutputStream.toByteArray();
@@ -116,6 +119,7 @@ public class InternalInvoiceCreator implements InvoiceCreator {
 
 	private void processInvoiceRow(BeanWriter invoiceWriter, InvoiceRowEntity invoiceRow) {
 		invoiceWriter.write(toInvoiceRow(invoiceRow));
+		toInvoiceRowDescriptionRows(invoiceRow).forEach(invoiceWriter::write);
 		invoiceWriter.write(toInvoiceAccountingRow(invoiceRow));
 	}
 }

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/creator/config/InvoiceCreatorConfig.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/creator/config/InvoiceCreatorConfig.java
@@ -15,6 +15,7 @@ public class InvoiceCreatorConfig {
 
 	@Bean(INTERNAL_INVOICE_BUILDER)
 	StreamBuilder internalInvoiceStreamBuilder(InvoiceCreatorProperties properties) {
+
 		return new StreamBuilder(INTERNAL_INVOICE_BUILDER)
 			.format(FIXED_LENGTH)
 			.parser(new FixedLengthParserBuilder().recordTerminator(unescapeJava(properties.recordTerminator())))
@@ -24,6 +25,7 @@ public class InvoiceCreatorConfig {
 			.addRecord(se.sundsvall.billingpreprocessor.service.creator.definition.internal.InvoiceHeaderRow.class)
 			.addRecord(se.sundsvall.billingpreprocessor.service.creator.definition.internal.InvoiceDescriptionRow.class)
 			.addRecord(se.sundsvall.billingpreprocessor.service.creator.definition.internal.InvoiceRow.class)
+			.addRecord(se.sundsvall.billingpreprocessor.service.creator.definition.internal.InvoiceRowDescriptionRow.class)
 			.addRecord(se.sundsvall.billingpreprocessor.service.creator.definition.internal.InvoiceAccountingRow.class)
 			.addRecord(se.sundsvall.billingpreprocessor.service.creator.definition.internal.InvoiceFooterRow.class);
 	}

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/creator/definition/internal/InvoiceRowDescriptionRow.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/creator/definition/internal/InvoiceRowDescriptionRow.java
@@ -1,0 +1,54 @@
+package se.sundsvall.billingpreprocessor.service.creator.definition.internal;
+
+import java.util.Objects;
+
+import org.beanio.annotation.Field;
+import org.beanio.annotation.Fields;
+import org.beanio.annotation.Record;
+
+@Record
+@Fields({
+	@Field(at = 0, length = 2, name = "recordType", rid = true, literal = "U")
+})
+public class InvoiceRowDescriptionRow {
+
+	@Field(at = 2, length = 100)
+	private String description;
+
+	public static InvoiceRowDescriptionRow create() {
+		return new InvoiceRowDescriptionRow();
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public InvoiceRowDescriptionRow withDescription(String description) {
+		this.description = description;
+		return this;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(description);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) { return true; }
+		if (!(obj instanceof final InvoiceRowDescriptionRow other)) { return false; }
+		return Objects.equals(description, other.description);
+	}
+
+	@Override
+	public String toString() {
+		final var builder = new StringBuilder();
+		builder.append("InvoiceRowDescriptionRow [description=").append(description).append("]");
+		return builder.toString();
+	}
+
+}

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/mapper/InternalInvoiceMapper.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/mapper/InternalInvoiceMapper.java
@@ -13,8 +13,11 @@ import static se.sundsvall.billingpreprocessor.Constants.ERROR_INVOICE_NOT_PRESE
 import static se.sundsvall.billingpreprocessor.Constants.ERROR_OUR_REFERENCE_NOT_PRESENT;
 import static se.sundsvall.billingpreprocessor.Constants.ERROR_SUBACCOUNT_NOT_PRESENT;
 import static se.sundsvall.billingpreprocessor.Constants.ERROR_TOTAL_AMOUNT_NOT_PRESENT;
+import static se.sundsvall.billingpreprocessor.integration.db.model.enums.DescriptionType.DETAILED;
 import static se.sundsvall.billingpreprocessor.integration.db.model.enums.DescriptionType.STANDARD;
 import static se.sundsvall.billingpreprocessor.service.util.ProblemUtil.createInternalServerErrorProblem;
+
+import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.zalando.problem.ThrowableProblem;
@@ -28,13 +31,14 @@ import se.sundsvall.billingpreprocessor.service.creator.definition.internal.Invo
 import se.sundsvall.billingpreprocessor.service.creator.definition.internal.InvoiceFooterRow;
 import se.sundsvall.billingpreprocessor.service.creator.definition.internal.InvoiceHeaderRow;
 import se.sundsvall.billingpreprocessor.service.creator.definition.internal.InvoiceRow;
+import se.sundsvall.billingpreprocessor.service.creator.definition.internal.InvoiceRowDescriptionRow;
 
 public class InternalInvoiceMapper {
 	private InternalInvoiceMapper() {}
 
 	/**
 	 * method for creating file header row for internal invoice files
-	 * 
+	 *
 	 * @return FileHeaderRow for internal invoice files
 	 */
 	public static FileHeaderRow toFileHeader() {
@@ -43,7 +47,7 @@ public class InternalInvoiceMapper {
 
 	/**
 	 * Method for mapping invoice data to a invoice header row for an internal invoice file
-	 * 
+	 *
 	 * @param  billingRecordEntity entity representing the billingRecordEntity
 	 * @return                     InvoiceHeaderRow for internal invoice files representing provided data
 	 * @throws ThrowableProblem    if any mandatory data is missing
@@ -61,7 +65,7 @@ public class InternalInvoiceMapper {
 
 	/**
 	 * Method for mapping invoice data to a invoice description row for an internal invoice file
-	 * 
+	 *
 	 * @param  billingRecordEntity entity representing the billingRecordEntity
 	 * @return                     InvoiceDescriptionRow for internal invoice files representing provided data
 	 * @throws ThrowableProblem    if any mandatory data is missing
@@ -74,8 +78,29 @@ public class InternalInvoiceMapper {
 	}
 
 	/**
+	 * Method for mapping invoice row data to an invoice description row for an internal invoice file. Description rows
+	 * in entity with DescriptionType DETAILED will be transformed to a InvoiceRowDescriptionRow
+	 *
+	 * @param  invoiceRowEntity entity representing the invoiceRowEntity
+	 * @return                  A list of InvoiceRowDescriptionRow representing provided data
+	 */
+	public static List<InvoiceRowDescriptionRow> toInvoiceRowDescriptionRows(InvoiceRowEntity invoiceRowEntity) {
+		return ofNullable(invoiceRowEntity.getDescriptions()).orElse(emptyList()).stream()
+			.filter(description -> description.getType() == DETAILED)
+			.map(DescriptionEntity::getText)
+			.filter(StringUtils::isNotBlank)
+			.map(InternalInvoiceMapper::toInvoiceRowDescriptionRow)
+			.toList();
+	}
+
+	private static InvoiceRowDescriptionRow toInvoiceRowDescriptionRow(String text) {
+		return InvoiceRowDescriptionRow.create()
+			.withDescription(text);
+	}
+
+	/**
 	 * Method for mapping invoice row data to a invoice row for an internal invoice file
-	 * 
+	 *
 	 * @param  invoiceRowEntity entity representing the invoiceRowEntity
 	 * @return                  InvoiceRow for internal invoice files representing provided data
 	 * @throws ThrowableProblem if any mandatory data is missing
@@ -90,7 +115,7 @@ public class InternalInvoiceMapper {
 
 	/**
 	 * Method for mapping invoice accounting row data to a invoice row for an internal invoice file
-	 * 
+	 *
 	 * @param  invoiceRowEntity entity representing the invoiceRowEntity
 	 * @return                  InvoiceAccountingRow for internal invoice files representing provided data
 	 * @throws ThrowableProblem if any mandatory data is missing
@@ -111,7 +136,7 @@ public class InternalInvoiceMapper {
 	}
 
 	/**
-	 * 
+	 *
 	 * @param  invoiceEntity
 	 * @return
 	 */

--- a/src/test/java/se/sundsvall/billingpreprocessor/api/BillingRecordsCreateResourceFailureTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/api/BillingRecordsCreateResourceFailureTest.java
@@ -111,7 +111,6 @@ class BillingRecordsCreateResourceFailureTest {
 		assertThat(response.getTitle()).isEqualTo("Constraint Violation");
 		assertThat(response.getStatus()).isEqualTo(BAD_REQUEST);
 		assertThat(response.getViolations()).extracting(Violation::getField, Violation::getMessage).containsExactlyInAnyOrder(
-			tuple("billingRecord", "can not contain detailed description on invoice rows when billing record is of type INTERNAL"),
 			tuple("billingRecord", "can not contain vat code information on invoice rows when billing record is of type INTERNAL"),
 			tuple("billingRecord", "invoice.ourReference is mandatory when billing record is of type INTERNAL"),
 			tuple("billingRecord", "invoice.referenceId is mandatory when billing record is of type INTERNAL"),

--- a/src/test/java/se/sundsvall/billingpreprocessor/api/BillingRecordsReadResourceFailureTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/api/BillingRecordsReadResourceFailureTest.java
@@ -1,6 +1,5 @@
 package se.sundsvall.billingpreprocessor.api;
 
-import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
 import static org.mockito.Mockito.verifyNoInteractions;

--- a/src/test/java/se/sundsvall/billingpreprocessor/api/BillingRecordsUpdateResourceFailureTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/api/BillingRecordsUpdateResourceFailureTest.java
@@ -147,7 +147,6 @@ class BillingRecordsUpdateResourceFailureTest {
 		assertThat(response.getTitle()).isEqualTo("Constraint Violation");
 		assertThat(response.getStatus()).isEqualTo(BAD_REQUEST);
 		assertThat(response.getViolations()).extracting(Violation::getField, Violation::getMessage).containsExactlyInAnyOrder(
-			tuple("billingRecord", "can not contain detailed description on invoice rows when billing record is of type INTERNAL"),
 			tuple("billingRecord", "can not contain vat code information on invoice rows when billing record is of type INTERNAL"),
 			tuple("billingRecord", "invoice.ourReference is mandatory when billing record is of type INTERNAL"),
 			tuple("billingRecord", "invoice.referenceId is mandatory when billing record is of type INTERNAL"),

--- a/src/test/java/se/sundsvall/billingpreprocessor/api/validation/impl/ValidInvoiceConstraintValidatorTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/api/validation/impl/ValidInvoiceConstraintValidatorTest.java
@@ -1,17 +1,5 @@
 package se.sundsvall.billingpreprocessor.api.validation.impl;
 
-import jakarta.validation.ConstraintValidatorContext;
-import jakarta.validation.ConstraintValidatorContext.ConstraintViolationBuilder;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import se.sundsvall.billingpreprocessor.api.model.BillingRecord;
-import se.sundsvall.billingpreprocessor.api.model.Invoice;
-import se.sundsvall.billingpreprocessor.api.model.InvoiceRow;
-
-import java.util.List;
-
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -20,6 +8,19 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static se.sundsvall.billingpreprocessor.api.model.enums.Type.EXTERNAL;
 import static se.sundsvall.billingpreprocessor.api.model.enums.Type.INTERNAL;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.ConstraintValidatorContext.ConstraintViolationBuilder;
+import se.sundsvall.billingpreprocessor.api.model.BillingRecord;
+import se.sundsvall.billingpreprocessor.api.model.Invoice;
+import se.sundsvall.billingpreprocessor.api.model.InvoiceRow;
 
 @ExtendWith(MockitoExtension.class)
 class ValidInvoiceConstraintValidatorTest {
@@ -30,7 +31,7 @@ class ValidInvoiceConstraintValidatorTest {
 	@Mock
 	private ConstraintViolationBuilder builderMock;
 
-	private ValidInvoiceConstraintValidator validator = new ValidInvoiceConstraintValidator();
+	private final ValidInvoiceConstraintValidator validator = new ValidInvoiceConstraintValidator();
 
 	@Test
 	void withExternalType() {
@@ -78,20 +79,6 @@ class ValidInvoiceConstraintValidatorTest {
 		assertThat(validator.isValid(billingRecord, contextMock)).isTrue();
 
 		verifyNoInteractions(contextMock, builderMock);
-	}
-
-	@Test
-	void withInternalTypeAndDetailDescriptionsPresent() {
-		final var billingRecord = BillingRecord.create().withType(INTERNAL).withInvoice(Invoice.create().withReferenceId("refId").withOurReference("ourRef").withInvoiceRows(List.of(InvoiceRow.create().withDetailedDescriptions(List.of(
-			"detailedDescription")))));
-
-		when(contextMock.buildConstraintViolationWithTemplate(any())).thenReturn(builderMock);
-
-		assertThat(validator.isValid(billingRecord, contextMock)).isFalse();
-
-		verify(contextMock).disableDefaultConstraintViolation();
-		verify(contextMock).buildConstraintViolationWithTemplate("can not contain detailed description on invoice rows when billing record is of type INTERNAL");
-		verify(builderMock).addConstraintViolation();
 	}
 
 	@Test

--- a/src/test/java/se/sundsvall/billingpreprocessor/service/creator/InternalInvoiceCreatorTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/service/creator/InternalInvoiceCreatorTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.zalando.problem.Status.INTERNAL_SERVER_ERROR;
+import static se.sundsvall.billingpreprocessor.integration.db.model.enums.DescriptionType.DETAILED;
 import static se.sundsvall.billingpreprocessor.integration.db.model.enums.DescriptionType.STANDARD;
 import static se.sundsvall.billingpreprocessor.integration.db.model.enums.Type.INTERNAL;
 
@@ -52,6 +53,7 @@ class InternalInvoiceCreatorTest {
 	// Invoice row constants
 	private static final float COST_PER_UNIT = 1500f;
 	private static final String DESCRIPTION = "Uppdrag: ABC-123";
+	private static final String DETAILED_DESCRIPTION = "En mer detaljerad fakturaradsbeskrivning";
 	private static final float QUANTITY = 1f;
 
 	// Account information constants
@@ -186,7 +188,8 @@ class InternalInvoiceCreatorTest {
 			.withTotalAmount(COST_PER_UNIT * QUANTITY);
 
 		return invoiceRowEntity.withDescriptions(List.of(
-			createDescriptionEntity(1, invoiceRowEntity, STANDARD, DESCRIPTION)));
+			createDescriptionEntity(1, invoiceRowEntity, STANDARD, DESCRIPTION),
+			createDescriptionEntity(2, invoiceRowEntity, DETAILED, DETAILED_DESCRIPTION)));
 	}
 
 	private static DescriptionEntity createDescriptionEntity(int id, InvoiceRowEntity invoiceRowEntity, DescriptionType type, String text) {

--- a/src/test/java/se/sundsvall/billingpreprocessor/service/creator/config/InvoiceCreatorConfigTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/service/creator/config/InvoiceCreatorConfigTest.java
@@ -69,6 +69,7 @@ class InvoiceCreatorConfigTest {
 				tuple("fileHeaderRow", "se.sundsvall.billingpreprocessor.service.creator.definition.internal.FileHeaderRow"),
 				tuple("invoiceHeaderRow", "se.sundsvall.billingpreprocessor.service.creator.definition.internal.InvoiceHeaderRow"),
 				tuple("invoiceRow", "se.sundsvall.billingpreprocessor.service.creator.definition.internal.InvoiceRow"),
+				tuple("invoiceRowDescriptionRow", "se.sundsvall.billingpreprocessor.service.creator.definition.internal.InvoiceRowDescriptionRow"),
 				tuple("invoiceDescriptionRow", "se.sundsvall.billingpreprocessor.service.creator.definition.internal.InvoiceDescriptionRow"),
 				tuple("invoiceAccountingRow", "se.sundsvall.billingpreprocessor.service.creator.definition.internal.InvoiceAccountingRow"),
 				tuple("invoiceFooterRow", "se.sundsvall.billingpreprocessor.service.creator.definition.internal.InvoiceFooterRow"));

--- a/src/test/java/se/sundsvall/billingpreprocessor/service/creator/definition/internal/InvoiceRowDescriptionRowTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/service/creator/definition/internal/InvoiceRowDescriptionRowTest.java
@@ -1,0 +1,41 @@
+package se.sundsvall.billingpreprocessor.service.creator.definition.internal;
+
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanConstructor;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanEquals;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanHashCode;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanToString;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidGettersAndSetters;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class InvoiceRowDescriptionRowTest {
+
+	@Test
+	void testBean() {
+		assertThat(InvoiceRowDescriptionRow.class, allOf(
+			hasValidBeanConstructor(),
+			hasValidGettersAndSetters(),
+			hasValidBeanHashCode(),
+			hasValidBeanEquals(),
+			hasValidBeanToString()));
+	}
+
+	@Test
+	void testBuilderMethods() {
+		final var description = "description";
+
+		final var bean = InvoiceRowDescriptionRow.create()
+			.withDescription(description);
+
+		assertThat(bean.getDescription()).isEqualTo(description);
+	}
+
+	@Test
+	void testNoDirtOnCreatedBean() {
+		assertThat(new InvoiceDescriptionRow()).hasAllNullFieldsOrProperties();
+		assertThat(InvoiceDescriptionRow.create()).hasAllNullFieldsOrProperties();
+	}
+}

--- a/src/test/java/se/sundsvall/billingpreprocessor/service/scheduler/InvoiceFileSchedulerTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/service/scheduler/InvoiceFileSchedulerTest.java
@@ -4,6 +4,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -16,9 +18,6 @@ import se.sundsvall.billingpreprocessor.integration.sftp.SftpProperties;
 import se.sundsvall.billingpreprocessor.integration.sftp.SftpPropertiesConfig;
 import se.sundsvall.billingpreprocessor.service.InvoiceFileService;
 import se.sundsvall.dept44.requestid.RequestId;
-
-import java.util.Map;
-import java.util.Set;
 
 @ExtendWith(MockitoExtension.class)
 class InvoiceFileSchedulerTest {

--- a/src/test/java/se/sundsvall/billingpreprocessor/service/util/ProblemUtilTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/service/util/ProblemUtilTest.java
@@ -12,7 +12,7 @@ class ProblemUtilTest {
 
 	@Test
 	void testCreateInternalServerErrorProblem() {
-		final var message = RandomStringUtils.randomAlphabetic(10);
+		final var message = RandomStringUtils.secure().nextAlphabetic(10);
 		final var problem = createInternalServerErrorProblem(message).get();
 
 		assertThat(problem).isNotNull();
@@ -23,7 +23,7 @@ class ProblemUtilTest {
 	@Test
 	void testCreateProblem() {
 		final var status = Status.I_AM_A_TEAPOT;
-		final var message = RandomStringUtils.randomAlphabetic(10);
+		final var message = RandomStringUtils.secure().nextAlphabetic(10);
 		final var problem = createProblem(status, message).get();
 
 		assertThat(problem).isNotNull();

--- a/src/test/resources/db/scripts/testdata-it.sql
+++ b/src/test/resources/db/scripts/testdata-it.sql
@@ -36,13 +36,13 @@ VALUES	(100, NULL, '5247000', '1620000', 'MIC00GOL', '910300', NULL, NULL, '9361
 -------------------------------------
 INSERT INTO description (text, `type`, invoice_row_id)
 VALUES	('Ordernummer: azi-330c-3fne-33', 'STANDARD', 100),
-		('Beställare: MIC00GOL 22940338', 'STANDARD', 100),
-		('Användare: Rocky Balboa ROC01BAL', 'STANDARD', 100),
-		('Passerkort utan foto', 'STANDARD', 100),
+		('Beställare: MIC00GOL 22940338', 'DETAILED', 100),
+		('Användare: Rocky Balboa ROC01BAL', 'DETAILED', 100),
+		('Passerkort utan foto', 'DETAILED', 100),
 		('Ordernummer: ewf-3fee-boe3-74', 'STANDARD', 200),
-		('Beställare: MAN22VEG 4480296', 'STANDARD', 200),
-		('Användare: Ivan Drago IVA02DRA', 'STANDARD', 200),
-		('Passerkort med foto', 'STANDARD', 200),
+		('Beställare: MAN22VEG 4480296', 'DETAILED', 200),
+		('Användare: Ivan Drago IVA02DRA', 'DETAILED', 200),
+		('Passerkort med foto', 'DETAILED', 200),
 		('Styrka: 100mg', 'STANDARD', 400);
 
 -------------------------------------

--- a/src/test/resources/validation/internal_invoicedata_expected_format.txt
+++ b/src/test/resources/validation/internal_invoicedata_expected_format.txt
@@ -1,5 +1,6 @@
 H 16        2024030620240330           5ABC30DEF                                                      Johnny Bråttom                
 R Extra utbetalning - Direktinsättning                                                                
 R Uppdrag: ABC-123                                       1.00      1500.00                       1500.00
+U En mer detaljerad fakturaradsbeskrivning                                                            
 K 15800100  936300    920360    5756      11041     117       116                                              1500.00 117          
 T 1500.00        


### PR DESCRIPTION
- Removed validation of "no detailed description rows for internal invoices"
- Extended internal invoice creator to add U-rows for each found detailedDescription-row

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [x] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
