### PR TITLE
HYDRAN-28: Generate single total amount

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>se.sundsvall</groupId>
 	<artifactId>api-service-billing-preprocessor</artifactId>
-	<version>4.0</version>
+	<version>5.0</version>
 	<name>api-service-billing-preprocessor</name>
 	<properties>
 		<!-- Service properties -->

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>se.sundsvall</groupId>
 	<artifactId>api-service-billing-preprocessor</artifactId>
-	<version>5.0</version>
+	<version>4.0</version>
 	<name>api-service-billing-preprocessor</name>
 	<properties>
 		<!-- Service properties -->

--- a/src/integration-test/resources/SalaryAndPensionJobsIT/__files/test01_createInvoiceFiles/filecontent/expected_external_content.txt
+++ b/src/integration-test/resources/SalaryAndPensionJobsIT/__files/test01_createInvoiceFiles/filecontent/expected_external_content.txt
@@ -1,7 +1,10 @@
 !BillingPreProcessor yyMMdd Extern debitering                                                                                                             
+S6512345678Acme Corporation                                                      FOO BAR BAZ 860                    42012 FOOTOWN                      510
+H6512345678      BOB99                         Lola Macarola                 
+R6512345678Utvecklingskostnad 2%         200     24500    49000          25
+K15800234363000920360575711041       510000000000738             
 S6512345678Seaview Middle School                                                 MIDDLE SCHOOL STREET 123           90102 HANZALAND                    510
 H6512345678      PRI22LUG                      Hanna Montana                 
 R6512345678Ärendenummer: LoP-25020125    123     30600    37638          25
 K158002343630009203605757            510000000036900             
-K15800234363000920360575711041       510000000000738             
-T+00000000037638
+T+00000000086638

--- a/src/integration-test/resources/SalaryAndPensionJobsIT/__files/test01_createInvoiceFiles/filecontent/expected_internal_content.txt
+++ b/src/integration-test/resources/SalaryAndPensionJobsIT/__files/test01_createInvoiceFiles/filecontent/expected_internal_content.txt
@@ -1,8 +1,14 @@
 01300SKC
+H 20                                   ZXZ99YXY                                                       John Doe                      
+R Extra löneutbetalning - Direktinsättning                                                            
+R Ärendenummer: LoP-21235020                             1.00       300.00                        300.00
+K 15810100  936300    920360    5756                          110                                               300.00              
+R Utvecklingskostnad 2%                                  1.00         6.00                          6.00
+K 15810100  936300    920360    5756                          110                                                 6.00              
 H 10                                   HAN99MON                                                       Lola Luftnagle                
 R Extra löneutbetalning - Direktinsättning                                                            
 R Ärendenummer: LoP-25020123                             1.00      1500.00                       1500.00
 K 15810100  936300    920360    5756                          110                                              1500.00              
 R Utvecklingskostnad 2%                                  1.00        30.00                         30.00
 K 15810100  936300    920360    5756                          110                                                30.00              
-T 1530.00        
+T 1836.00        

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/InvoiceFileService.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/InvoiceFileService.java
@@ -137,6 +137,8 @@ public class InvoiceFileService {
 				billingRecordsToProcess.forEach(billingRecord -> createBillingRecord(outputStream, billingRecord, invoiceCreator)
 					.ifPresent(billingRecordProcessErrors::add));
 
+				outputStream.write(invoiceCreator.createFileFooter(billingRecordsToProcess));
+
 				if (billingRecordsToProcess.size() > billingRecordProcessErrors.size()) { // At least one of the records should be successful for the file to be created
 					invoiceFileRepository.save(toInvoiceFileEntity(filename, type.name(), outputStream.toByteArray(), encoding, municipalityId));
 				}

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/creator/ExternalInvoiceCreator.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/creator/ExternalInvoiceCreator.java
@@ -33,9 +33,10 @@ import se.sundsvall.billingpreprocessor.integration.db.model.enums.Type;
 
 @Component
 public class ExternalInvoiceCreator implements InvoiceCreator {
-	private final StreamFactory factory;
-	private final LegalIdProvider legalIdProvider;
-	private final InvoiceFileConfigurationRepository configurationRepository;
+
+	protected final StreamFactory factory;
+	protected final LegalIdProvider legalIdProvider;
+	protected final InvoiceFileConfigurationRepository configurationRepository;
 
 	public ExternalInvoiceCreator(@Qualifier(EXTERNAL_INVOICE_BUILDER) StreamBuilder builder, LegalIdProvider legalIdProvider, InvoiceFileConfigurationRepository configurationRepository) {
 		this.factory = StreamFactory.newInstance();
@@ -44,7 +45,7 @@ public class ExternalInvoiceCreator implements InvoiceCreator {
 		this.configurationRepository = configurationRepository;
 	}
 
-	private InvoiceFileConfigurationEntity getConfiguration() {
+	protected InvoiceFileConfigurationEntity getConfiguration() {
 		return configurationRepository.findByCreatorName(this.getClass().getSimpleName())
 			.orElseThrow(createInternalServerErrorProblem(CONFIGURATION_NOT_PRESENT.formatted(this.getClass().getSimpleName())));
 	}
@@ -108,7 +109,7 @@ public class ExternalInvoiceCreator implements InvoiceCreator {
 		}
 	}
 
-	private void processInvoice(BeanWriter invoiceWriter, BillingRecordEntity billingRecord) {
+	protected void processInvoice(BeanWriter invoiceWriter, BillingRecordEntity billingRecord) {
 		final var recipientLegalId = extractLegalId(billingRecord);
 
 		invoiceWriter.write(toCustomer(recipientLegalId, billingRecord));
@@ -122,13 +123,13 @@ public class ExternalInvoiceCreator implements InvoiceCreator {
 		invoiceWriter.write(toInvoiceFooter(billingRecord));
 	}
 
-	private void processInvoiceRow(BeanWriter invoiceWriter, String recipientLegalId, InvoiceRowEntity invoiceRow) {
+	protected void processInvoiceRow(BeanWriter invoiceWriter, String recipientLegalId, InvoiceRowEntity invoiceRow) {
 		invoiceWriter.write(toInvoiceRow(recipientLegalId, invoiceRow));
 		toInvoiceDescriptionRows(recipientLegalId, invoiceRow).forEach(invoiceWriter::write);
 		toInvoiceAccountingRows(invoiceRow).forEach(invoiceWriter::write);
 	}
 
-	private String extractLegalId(BillingRecordEntity billingRecord) {
+	protected String extractLegalId(BillingRecordEntity billingRecord) {
 		final var legalId = ofNullable(billingRecord.getRecipient().getLegalId())
 			.orElseGet(() -> legalIdProvider.translateToLegalId(billingRecord.getMunicipalityId(), billingRecord.getRecipient().getPartyId()));
 

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/creator/ExternalSalaryAndPensionInvoiceCreator.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/creator/ExternalSalaryAndPensionInvoiceCreator.java
@@ -42,7 +42,7 @@ public class ExternalSalaryAndPensionInvoiceCreator extends ExternalInvoiceCreat
 
 		final var encoding = Charset.forName(getConfiguration().getEncoding());
 		try (var byteArrayOutputStream = new ByteArrayOutputStream();
-			var invoiceWriter = factory.createWriter(EXTERNAL_INVOICE_BUILDER, new OutputStreamWriter(byteArrayOutputStream, encoding))) {
+			var invoiceWriter = getFactory().createWriter(EXTERNAL_INVOICE_BUILDER, new OutputStreamWriter(byteArrayOutputStream, encoding))) {
 			invoiceWriter.write(toFileFooter(billingRecords));
 			invoiceWriter.flush();
 			return byteArrayOutputStream.toByteArray();
@@ -50,7 +50,7 @@ public class ExternalSalaryAndPensionInvoiceCreator extends ExternalInvoiceCreat
 	}
 
 	@Override
-	protected void processInvoice(BeanWriter invoiceWriter, BillingRecordEntity billingRecord) {
+	void processInvoice(BeanWriter invoiceWriter, BillingRecordEntity billingRecord) {
 		final var recipientLegalId = extractLegalId(billingRecord);
 
 		invoiceWriter.write(toCustomer(recipientLegalId, billingRecord));

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/creator/ExternalSalaryAndPensionInvoiceCreator.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/creator/ExternalSalaryAndPensionInvoiceCreator.java
@@ -1,16 +1,64 @@
 package se.sundsvall.billingpreprocessor.service.creator;
 
+import static java.util.Optional.ofNullable;
+import static se.sundsvall.billingpreprocessor.Constants.EMPTY_ARRAY;
 import static se.sundsvall.billingpreprocessor.service.creator.config.InvoiceCreatorConfig.EXTERNAL_INVOICE_BUILDER;
+import static se.sundsvall.billingpreprocessor.service.mapper.ExternalInvoiceMapper.toCustomer;
+import static se.sundsvall.billingpreprocessor.service.mapper.ExternalInvoiceMapper.toFileFooter;
+import static se.sundsvall.billingpreprocessor.service.util.ProblemUtil.createInternalServerErrorProblem;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
+import java.util.List;
+import org.beanio.BeanWriter;
 import org.beanio.builder.StreamBuilder;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import se.sundsvall.billingpreprocessor.integration.db.InvoiceFileConfigurationRepository;
+import se.sundsvall.billingpreprocessor.integration.db.model.BillingRecordEntity;
+import se.sundsvall.billingpreprocessor.service.mapper.ExternalInvoiceMapper;
 
 @Component
 public class ExternalSalaryAndPensionInvoiceCreator extends ExternalInvoiceCreator {
 
 	public ExternalSalaryAndPensionInvoiceCreator(@Qualifier(EXTERNAL_INVOICE_BUILDER) StreamBuilder builder, LegalIdProvider legalIdProvider, InvoiceFileConfigurationRepository configurationRepository) {
 		super(builder, legalIdProvider, configurationRepository);
+	}
+
+	/**
+	 * Creates a file footer according to the specification for external salary and pension invoices
+	 *
+	 * @param  billingRecords containing the billing record to produce a file footer section for
+	 * @return                byte array representing the file footer
+	 * @throws IOException    if the byte array output stream cannot be closed
+	 */
+	@Override
+	public byte[] createFileFooter(List<BillingRecordEntity> billingRecords) throws IOException {
+		if (billingRecords.isEmpty()) {
+			return EMPTY_ARRAY;
+		}
+
+		final var encoding = Charset.forName(getConfiguration().getEncoding());
+		try (var byteArrayOutputStream = new ByteArrayOutputStream();
+			var invoiceWriter = factory.createWriter(EXTERNAL_INVOICE_BUILDER, new OutputStreamWriter(byteArrayOutputStream, encoding))) {
+			invoiceWriter.write(toFileFooter(billingRecords));
+			invoiceWriter.flush();
+			return byteArrayOutputStream.toByteArray();
+		}
+	}
+
+	@Override
+	protected void processInvoice(BeanWriter invoiceWriter, BillingRecordEntity billingRecord) {
+		final var recipientLegalId = extractLegalId(billingRecord);
+
+		invoiceWriter.write(toCustomer(recipientLegalId, billingRecord));
+		invoiceWriter.write(ExternalInvoiceMapper.toInvoiceHeader(recipientLegalId, billingRecord));
+
+		ofNullable(billingRecord.getInvoice())
+			.orElseThrow(createInternalServerErrorProblem("Invoice is not present"))
+			.getInvoiceRows()
+			.forEach(row -> processInvoiceRow(invoiceWriter, recipientLegalId, row));
 	}
 }

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/creator/InternalInvoiceCreator.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/creator/InternalInvoiceCreator.java
@@ -31,8 +31,8 @@ import se.sundsvall.billingpreprocessor.integration.db.model.enums.Type;
 @Component
 public class InternalInvoiceCreator implements InvoiceCreator {
 
-	protected final InvoiceFileConfigurationRepository configurationRepository;
-	protected final StreamFactory factory;
+	private final InvoiceFileConfigurationRepository configurationRepository;
+	private final StreamFactory factory;
 
 	public InternalInvoiceCreator(@Qualifier(INTERNAL_INVOICE_BUILDER) StreamBuilder builder, InvoiceFileConfigurationRepository configurationRepository) {
 		this.factory = StreamFactory.newInstance();
@@ -40,9 +40,13 @@ public class InternalInvoiceCreator implements InvoiceCreator {
 		this.configurationRepository = configurationRepository;
 	}
 
-	protected InvoiceFileConfigurationEntity getConfiguration() {
+	InvoiceFileConfigurationEntity getConfiguration() {
 		return configurationRepository.findByCreatorName(this.getClass().getSimpleName())
 			.orElseThrow(createInternalServerErrorProblem(CONFIGURATION_NOT_PRESENT.formatted(this.getClass().getSimpleName())));
+	}
+
+	StreamFactory getFactory() {
+		return factory;
 	}
 
 	/**
@@ -104,7 +108,7 @@ public class InternalInvoiceCreator implements InvoiceCreator {
 		}
 	}
 
-	protected void processInvoice(BeanWriter invoiceWriter, BillingRecordEntity billingRecord) {
+	void processInvoice(BeanWriter invoiceWriter, BillingRecordEntity billingRecord) {
 		invoiceWriter.write(toInvoiceHeader(billingRecord));
 		invoiceWriter.write(toInvoiceDescriptionRow(billingRecord));
 
@@ -116,7 +120,7 @@ public class InternalInvoiceCreator implements InvoiceCreator {
 		invoiceWriter.write(toInvoiceFooter(billingRecord));
 	}
 
-	protected void processInvoiceRow(BeanWriter invoiceWriter, InvoiceRowEntity invoiceRow) {
+	void processInvoiceRow(BeanWriter invoiceWriter, InvoiceRowEntity invoiceRow) {
 		invoiceWriter.write(toInvoiceRow(invoiceRow));
 		toInvoiceRowDescriptionRows(invoiceRow).forEach(invoiceWriter::write);
 		toInvoiceAccountingRows(invoiceRow).forEach(invoiceWriter::write);

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/creator/InternalInvoiceCreator.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/creator/InternalInvoiceCreator.java
@@ -30,8 +30,9 @@ import se.sundsvall.billingpreprocessor.integration.db.model.enums.Type;
 
 @Component
 public class InternalInvoiceCreator implements InvoiceCreator {
-	private final InvoiceFileConfigurationRepository configurationRepository;
-	private final StreamFactory factory;
+
+	protected final InvoiceFileConfigurationRepository configurationRepository;
+	protected final StreamFactory factory;
 
 	public InternalInvoiceCreator(@Qualifier(INTERNAL_INVOICE_BUILDER) StreamBuilder builder, InvoiceFileConfigurationRepository configurationRepository) {
 		this.factory = StreamFactory.newInstance();
@@ -39,7 +40,7 @@ public class InternalInvoiceCreator implements InvoiceCreator {
 		this.configurationRepository = configurationRepository;
 	}
 
-	private InvoiceFileConfigurationEntity getConfiguration() {
+	protected InvoiceFileConfigurationEntity getConfiguration() {
 		return configurationRepository.findByCreatorName(this.getClass().getSimpleName())
 			.orElseThrow(createInternalServerErrorProblem(CONFIGURATION_NOT_PRESENT.formatted(this.getClass().getSimpleName())));
 	}
@@ -103,7 +104,7 @@ public class InternalInvoiceCreator implements InvoiceCreator {
 		}
 	}
 
-	private void processInvoice(BeanWriter invoiceWriter, BillingRecordEntity billingRecord) {
+	protected void processInvoice(BeanWriter invoiceWriter, BillingRecordEntity billingRecord) {
 		invoiceWriter.write(toInvoiceHeader(billingRecord));
 		invoiceWriter.write(toInvoiceDescriptionRow(billingRecord));
 
@@ -115,7 +116,7 @@ public class InternalInvoiceCreator implements InvoiceCreator {
 		invoiceWriter.write(toInvoiceFooter(billingRecord));
 	}
 
-	private void processInvoiceRow(BeanWriter invoiceWriter, InvoiceRowEntity invoiceRow) {
+	protected void processInvoiceRow(BeanWriter invoiceWriter, InvoiceRowEntity invoiceRow) {
 		invoiceWriter.write(toInvoiceRow(invoiceRow));
 		toInvoiceRowDescriptionRows(invoiceRow).forEach(invoiceWriter::write);
 		toInvoiceAccountingRows(invoiceRow).forEach(invoiceWriter::write);

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/creator/InternalSalaryAndPensionInvoiceCreator.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/creator/InternalSalaryAndPensionInvoiceCreator.java
@@ -42,7 +42,7 @@ public class InternalSalaryAndPensionInvoiceCreator extends InternalInvoiceCreat
 
 		final var encoding = Charset.forName(getConfiguration().getEncoding());
 		try (var byteArrayOutputStream = new ByteArrayOutputStream();
-			var invoiceWriter = factory.createWriter(INTERNAL_INVOICE_BUILDER, new OutputStreamWriter(byteArrayOutputStream, encoding))) {
+			var invoiceWriter = getFactory().createWriter(INTERNAL_INVOICE_BUILDER, new OutputStreamWriter(byteArrayOutputStream, encoding))) {
 			invoiceWriter.write(toFileFooter(billingRecords));
 			invoiceWriter.flush();
 			return byteArrayOutputStream.toByteArray();
@@ -50,7 +50,7 @@ public class InternalSalaryAndPensionInvoiceCreator extends InternalInvoiceCreat
 	}
 
 	@Override
-	protected void processInvoice(BeanWriter invoiceWriter, BillingRecordEntity billingRecord) {
+	void processInvoice(BeanWriter invoiceWriter, BillingRecordEntity billingRecord) {
 		invoiceWriter.write(toInvoiceHeader(billingRecord));
 		invoiceWriter.write(toInvoiceDescriptionRow(billingRecord));
 

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/creator/InternalSalaryAndPensionInvoiceCreator.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/creator/InternalSalaryAndPensionInvoiceCreator.java
@@ -1,15 +1,62 @@
 package se.sundsvall.billingpreprocessor.service.creator;
 
+import static java.util.Optional.ofNullable;
+import static se.sundsvall.billingpreprocessor.Constants.EMPTY_ARRAY;
 import static se.sundsvall.billingpreprocessor.service.creator.config.InvoiceCreatorConfig.INTERNAL_INVOICE_BUILDER;
+import static se.sundsvall.billingpreprocessor.service.mapper.InternalInvoiceMapper.toFileFooter;
+import static se.sundsvall.billingpreprocessor.service.mapper.InternalInvoiceMapper.toInvoiceDescriptionRow;
+import static se.sundsvall.billingpreprocessor.service.mapper.InternalInvoiceMapper.toInvoiceHeader;
+import static se.sundsvall.billingpreprocessor.service.util.ProblemUtil.createInternalServerErrorProblem;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
+import java.util.List;
+import org.beanio.BeanWriter;
 import org.beanio.builder.StreamBuilder;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import se.sundsvall.billingpreprocessor.integration.db.InvoiceFileConfigurationRepository;
+import se.sundsvall.billingpreprocessor.integration.db.model.BillingRecordEntity;
 
 @Component
 public class InternalSalaryAndPensionInvoiceCreator extends InternalInvoiceCreator {
+
 	public InternalSalaryAndPensionInvoiceCreator(@Qualifier(INTERNAL_INVOICE_BUILDER) StreamBuilder builder, InvoiceFileConfigurationRepository configurationRepository) {
 		super(builder, configurationRepository);
+	}
+
+	/**
+	 * Creates a file footer according to the specification for internal salary and pension invoices
+	 *
+	 * @param  billingRecords containing the billing record to produce a file footer section for
+	 * @return                byte array representing the file footer
+	 * @throws IOException    if the byte array output stream cannot be closed
+	 */
+	@Override
+	public byte[] createFileFooter(List<BillingRecordEntity> billingRecords) throws IOException {
+		if (billingRecords.isEmpty()) {
+			return EMPTY_ARRAY;
+		}
+
+		final var encoding = Charset.forName(getConfiguration().getEncoding());
+		try (var byteArrayOutputStream = new ByteArrayOutputStream();
+			var invoiceWriter = factory.createWriter(INTERNAL_INVOICE_BUILDER, new OutputStreamWriter(byteArrayOutputStream, encoding))) {
+			invoiceWriter.write(toFileFooter(billingRecords));
+			invoiceWriter.flush();
+			return byteArrayOutputStream.toByteArray();
+		}
+	}
+
+	@Override
+	protected void processInvoice(BeanWriter invoiceWriter, BillingRecordEntity billingRecord) {
+		invoiceWriter.write(toInvoiceHeader(billingRecord));
+		invoiceWriter.write(toInvoiceDescriptionRow(billingRecord));
+
+		ofNullable(billingRecord.getInvoice())
+			.orElseThrow(createInternalServerErrorProblem("Invoice is not present"))
+			.getInvoiceRows()
+			.forEach(row -> processInvoiceRow(invoiceWriter, row));
 	}
 }

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/creator/InvoiceCreator.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/creator/InvoiceCreator.java
@@ -1,6 +1,9 @@
 package se.sundsvall.billingpreprocessor.service.creator;
 
+import static se.sundsvall.billingpreprocessor.Constants.EMPTY_ARRAY;
+
 import java.io.IOException;
+import java.util.List;
 import se.sundsvall.billingpreprocessor.integration.db.model.BillingRecordEntity;
 import se.sundsvall.billingpreprocessor.integration.db.model.enums.Type;
 
@@ -23,11 +26,24 @@ public interface InvoiceCreator {
 
 	/**
 	 * Method for creating a file header
-	 * 
-	 * @return             bytearray representing the file header
-	 * @throws IOException if byte array output stream can not be closed
+	 *
+	 * @return             byte array representing the file header
+	 * @throws IOException if the byte array output stream cannot be closed
 	 */
-	byte[] createFileHeader() throws IOException;
+	default byte[] createFileHeader() throws IOException {
+		return EMPTY_ARRAY;
+	}
+
+	/**
+	 * Method for creating a file footer
+	 *
+	 * @param  billingRecords containing the billing record to produce a file footer section for
+	 * @return                byte array representing the file footer
+	 * @throws IOException    if the byte array output stream cannot be closed
+	 */
+	default byte[] createFileFooter(List<BillingRecordEntity> billingRecords) throws IOException {
+		return EMPTY_ARRAY;
+	}
 
 	/**
 	 * Method for creating an invoice data section

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/creator/config/InvoiceCreatorConfig.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/creator/config/InvoiceCreatorConfig.java
@@ -27,7 +27,8 @@ public class InvoiceCreatorConfig {
 			.addRecord(se.sundsvall.billingpreprocessor.service.creator.definition.internal.InvoiceRow.class)
 			.addRecord(se.sundsvall.billingpreprocessor.service.creator.definition.internal.InvoiceRowDescriptionRow.class)
 			.addRecord(se.sundsvall.billingpreprocessor.service.creator.definition.internal.InvoiceAccountingRow.class)
-			.addRecord(se.sundsvall.billingpreprocessor.service.creator.definition.internal.InvoiceFooterRow.class);
+			.addRecord(se.sundsvall.billingpreprocessor.service.creator.definition.internal.InvoiceFooterRow.class)
+			.addRecord(se.sundsvall.billingpreprocessor.service.creator.definition.internal.FileFooterRow.class);
 	}
 
 	@Bean(EXTERNAL_INVOICE_BUILDER)
@@ -43,6 +44,7 @@ public class InvoiceCreatorConfig {
 			.addRecord(se.sundsvall.billingpreprocessor.service.creator.definition.external.InvoiceRow.class)
 			.addRecord(se.sundsvall.billingpreprocessor.service.creator.definition.external.InvoiceDescriptionRow.class)
 			.addRecord(se.sundsvall.billingpreprocessor.service.creator.definition.external.InvoiceAccountingRow.class)
-			.addRecord(se.sundsvall.billingpreprocessor.service.creator.definition.external.InvoiceFooterRow.class);
+			.addRecord(se.sundsvall.billingpreprocessor.service.creator.definition.external.InvoiceFooterRow.class)
+			.addRecord(se.sundsvall.billingpreprocessor.service.creator.definition.external.FileFooterRow.class);
 	}
 }

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/creator/definition/external/FileFooterRow.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/creator/definition/external/FileFooterRow.java
@@ -1,0 +1,62 @@
+package se.sundsvall.billingpreprocessor.service.creator.definition.external;
+
+import static org.beanio.builder.Align.RIGHT;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+import org.beanio.annotation.Field;
+import org.beanio.annotation.Fields;
+import org.beanio.annotation.Record;
+import se.sundsvall.billingpreprocessor.service.creator.config.ExternalInvoiceBigDecimalTypeHandler;
+
+@Record(minOccurs = 1, maxOccurs = 1)
+@Fields({
+	@Field(at = 0, length = 1, name = "recordType", rid = true, literal = "T")
+})
+public class FileFooterRow {
+
+	@Field(at = 1, length = 15, handlerName = ExternalInvoiceBigDecimalTypeHandler.NAME, format = "+00000000000000;-00000000000000", align = RIGHT)
+	private BigDecimal totalAmount;
+
+	private FileFooterRow() {}
+
+	public static FileFooterRow create() {
+		return new FileFooterRow();
+	}
+
+	public BigDecimal getTotalAmount() {
+		return totalAmount;
+	}
+
+	public void setTotalAmount(BigDecimal totalAmount) {
+		this.totalAmount = totalAmount;
+	}
+
+	public FileFooterRow withTotalAmount(BigDecimal totalAmount) {
+		this.totalAmount = totalAmount;
+		return this;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(totalAmount);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!(obj instanceof final FileFooterRow other)) {
+			return false;
+		}
+		return Objects.equals(totalAmount, other.totalAmount);
+	}
+
+	@Override
+	public String toString() {
+		final var builder = new StringBuilder();
+		builder.append("FileFooterRow [totalAmount=").append(totalAmount).append("]");
+		return builder.toString();
+	}
+}

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/creator/definition/internal/FileFooterRow.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/creator/definition/internal/FileFooterRow.java
@@ -1,0 +1,60 @@
+package se.sundsvall.billingpreprocessor.service.creator.definition.internal;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+import org.beanio.annotation.Field;
+import org.beanio.annotation.Fields;
+import org.beanio.annotation.Record;
+import se.sundsvall.billingpreprocessor.service.creator.config.InternalInvoiceBigDecimalTypeHandler;
+
+@Record(minOccurs = 1, maxOccurs = 1)
+@Fields({
+	@Field(at = 0, length = 2, name = "recordType", rid = true, literal = "T")
+})
+public class FileFooterRow {
+
+	@Field(at = 2, length = 15, handlerName = InternalInvoiceBigDecimalTypeHandler.NAME)
+	private BigDecimal totalAmount;
+
+	private FileFooterRow() {}
+
+	public static FileFooterRow create() {
+		return new FileFooterRow();
+	}
+
+	public BigDecimal getTotalAmount() {
+		return totalAmount;
+	}
+
+	public void setTotalAmount(BigDecimal totalAmount) {
+		this.totalAmount = totalAmount;
+	}
+
+	public FileFooterRow withTotalAmount(BigDecimal totalAmount) {
+		this.totalAmount = totalAmount;
+		return this;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(totalAmount);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!(obj instanceof final FileFooterRow other)) {
+			return false;
+		}
+		return Objects.equals(totalAmount, other.totalAmount);
+	}
+
+	@Override
+	public String toString() {
+		final var builder = new StringBuilder();
+		builder.append("FileFooterRow [totalAmount=").append(totalAmount).append("]");
+		return builder.toString();
+	}
+}

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/mapper/ExternalInvoiceMapper.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/mapper/ExternalInvoiceMapper.java
@@ -22,9 +22,9 @@ import static se.sundsvall.billingpreprocessor.Constants.ERROR_SUBACCOUNT_NOT_PR
 import static se.sundsvall.billingpreprocessor.Constants.ERROR_VAT_CODE_NOT_PRESENT;
 import static se.sundsvall.billingpreprocessor.integration.db.model.enums.DescriptionType.DETAILED;
 import static se.sundsvall.billingpreprocessor.integration.db.model.enums.DescriptionType.STANDARD;
+import static se.sundsvall.billingpreprocessor.service.util.CalculationUtil.calculateTotalAmount;
 import static se.sundsvall.billingpreprocessor.service.util.ProblemUtil.createInternalServerErrorProblem;
 
-import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import org.apache.commons.collections4.CollectionUtils;
@@ -229,15 +229,5 @@ public final class ExternalInvoiceMapper {
 			.filter(StringUtils::isNotBlank)
 			.findFirst()
 			.orElse(null);
-	}
-
-	private static BigDecimal calculateTotalAmount(final List<BillingRecordEntity> billingRecords) {
-		return billingRecords.stream()
-			.map(BillingRecordEntity::getInvoice)
-			.map(InvoiceEntity::getInvoiceRows)
-			.flatMap(List::stream)
-			.map(InvoiceRowEntity::getTotalAmount)
-			.reduce(BigDecimal::add)
-			.orElse(BigDecimal.ZERO);
 	}
 }

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/mapper/ExternalInvoiceMapper.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/mapper/ExternalInvoiceMapper.java
@@ -68,7 +68,7 @@ public final class ExternalInvoiceMapper {
 	/**
 	 * Method for creating a file footer row for external invoice files
 	 *
-	 * @param  billingRecords entity representing the billingRecordEntity
+	 * @param  billingRecords list of billing records present in the file
 	 * @return                FileFooterRow for external invoice files
 	 */
 	public static FileFooterRow toFileFooter(final List<BillingRecordEntity> billingRecords) {

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/mapper/InternalInvoiceMapper.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/mapper/InternalInvoiceMapper.java
@@ -50,7 +50,7 @@ public final class InternalInvoiceMapper {
 	/**
 	 * Method for creating a file footer row for internal invoice files
 	 *
-	 * @param  billingRecords entity representing the billingRecordEntity
+	 * @param  billingRecords list of billing records present in the file
 	 * @return                FileFooterRow for internal invoice files
 	 */
 	public static FileFooterRow toFileFooter(List<BillingRecordEntity> billingRecords) {

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/mapper/InternalInvoiceMapper.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/mapper/InternalInvoiceMapper.java
@@ -17,12 +17,15 @@ import static se.sundsvall.billingpreprocessor.integration.db.model.enums.Descri
 import static se.sundsvall.billingpreprocessor.integration.db.model.enums.DescriptionType.STANDARD;
 import static se.sundsvall.billingpreprocessor.service.util.ProblemUtil.createInternalServerErrorProblem;
 
+import java.math.BigDecimal;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.zalando.problem.ThrowableProblem;
 import se.sundsvall.billingpreprocessor.integration.db.model.BillingRecordEntity;
 import se.sundsvall.billingpreprocessor.integration.db.model.DescriptionEntity;
+import se.sundsvall.billingpreprocessor.integration.db.model.InvoiceEntity;
 import se.sundsvall.billingpreprocessor.integration.db.model.InvoiceRowEntity;
+import se.sundsvall.billingpreprocessor.service.creator.definition.internal.FileFooterRow;
 import se.sundsvall.billingpreprocessor.service.creator.definition.internal.FileHeaderRow;
 import se.sundsvall.billingpreprocessor.service.creator.definition.internal.InvoiceAccountingRow;
 import se.sundsvall.billingpreprocessor.service.creator.definition.internal.InvoiceDescriptionRow;
@@ -42,6 +45,26 @@ public final class InternalInvoiceMapper {
 	 */
 	public static FileHeaderRow toFileHeader() {
 		return FileHeaderRow.create();
+	}
+
+	/**
+	 * Method for creating a file footer row for internal invoice files
+	 *
+	 * @param  billingRecords entity representing the billingRecordEntity
+	 * @return                FileFooterRow for internal invoice files
+	 */
+	public static FileFooterRow toFileFooter(List<BillingRecordEntity> billingRecords) {
+		final var total = billingRecords
+			.stream()
+			.map(BillingRecordEntity::getInvoice)
+			.map(InvoiceEntity::getInvoiceRows)
+			.flatMap(List::stream)
+			.map(InvoiceRowEntity::getTotalAmount)
+			.reduce(BigDecimal::add)
+			.orElse(BigDecimal.ZERO);
+
+		return FileFooterRow.create()
+			.withTotalAmount(total);
 	}
 
 	/**

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/mapper/InternalInvoiceMapper.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/mapper/InternalInvoiceMapper.java
@@ -15,15 +15,14 @@ import static se.sundsvall.billingpreprocessor.Constants.ERROR_SUBACCOUNT_NOT_PR
 import static se.sundsvall.billingpreprocessor.Constants.ERROR_TOTAL_AMOUNT_NOT_PRESENT;
 import static se.sundsvall.billingpreprocessor.integration.db.model.enums.DescriptionType.DETAILED;
 import static se.sundsvall.billingpreprocessor.integration.db.model.enums.DescriptionType.STANDARD;
+import static se.sundsvall.billingpreprocessor.service.util.CalculationUtil.calculateTotalAmount;
 import static se.sundsvall.billingpreprocessor.service.util.ProblemUtil.createInternalServerErrorProblem;
 
-import java.math.BigDecimal;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.zalando.problem.ThrowableProblem;
 import se.sundsvall.billingpreprocessor.integration.db.model.BillingRecordEntity;
 import se.sundsvall.billingpreprocessor.integration.db.model.DescriptionEntity;
-import se.sundsvall.billingpreprocessor.integration.db.model.InvoiceEntity;
 import se.sundsvall.billingpreprocessor.integration.db.model.InvoiceRowEntity;
 import se.sundsvall.billingpreprocessor.service.creator.definition.internal.FileFooterRow;
 import se.sundsvall.billingpreprocessor.service.creator.definition.internal.FileHeaderRow;
@@ -54,17 +53,8 @@ public final class InternalInvoiceMapper {
 	 * @return                FileFooterRow for internal invoice files
 	 */
 	public static FileFooterRow toFileFooter(List<BillingRecordEntity> billingRecords) {
-		final var total = billingRecords
-			.stream()
-			.map(BillingRecordEntity::getInvoice)
-			.map(InvoiceEntity::getInvoiceRows)
-			.flatMap(List::stream)
-			.map(InvoiceRowEntity::getTotalAmount)
-			.reduce(BigDecimal::add)
-			.orElse(BigDecimal.ZERO);
-
 		return FileFooterRow.create()
-			.withTotalAmount(total);
+			.withTotalAmount(calculateTotalAmount(billingRecords));
 	}
 
 	/**

--- a/src/main/java/se/sundsvall/billingpreprocessor/service/util/CalculationUtil.java
+++ b/src/main/java/se/sundsvall/billingpreprocessor/service/util/CalculationUtil.java
@@ -7,7 +7,10 @@ import static java.util.Optional.ofNullable;
 import static org.apache.commons.lang3.ObjectUtils.allNotNull;
 
 import java.math.BigDecimal;
+import java.util.List;
+import java.util.Objects;
 import se.sundsvall.billingpreprocessor.api.model.InvoiceRow;
+import se.sundsvall.billingpreprocessor.integration.db.model.BillingRecordEntity;
 import se.sundsvall.billingpreprocessor.integration.db.model.InvoiceEntity;
 import se.sundsvall.billingpreprocessor.integration.db.model.InvoiceRowEntity;
 
@@ -31,5 +34,22 @@ public final class CalculationUtil {
 			.filter(row -> nonNull(row.getTotalAmount()))
 			.map(InvoiceRowEntity::getTotalAmount)
 			.reduce(BigDecimal.ZERO, BigDecimal::add);
+	}
+
+	public static BigDecimal calculateTotalAmount(final List<BillingRecordEntity> billingRecords) {
+		if (isNull(billingRecords)) {
+			return BigDecimal.ZERO;
+		}
+
+		return billingRecords.stream()
+			.map(BillingRecordEntity::getInvoice)
+			.filter(Objects::nonNull)
+			.map(InvoiceEntity::getInvoiceRows)
+			.filter(Objects::nonNull)
+			.flatMap(List::stream)
+			.map(InvoiceRowEntity::getTotalAmount)
+			.filter(Objects::nonNull)
+			.reduce(BigDecimal::add)
+			.orElse(BigDecimal.ZERO);
 	}
 }

--- a/src/test/java/se/sundsvall/billingpreprocessor/service/creator/ExternalSalaryAndPensionInvoiceCreatorTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/service/creator/ExternalSalaryAndPensionInvoiceCreatorTest.java
@@ -1,13 +1,84 @@
 package se.sundsvall.billingpreprocessor.service.creator;
 
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.MOCK;
 
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import se.sundsvall.billingpreprocessor.integration.db.InvoiceFileConfigurationRepository;
+import se.sundsvall.billingpreprocessor.integration.db.model.BillingRecordEntity;
+import se.sundsvall.billingpreprocessor.integration.db.model.InvoiceEntity;
+import se.sundsvall.billingpreprocessor.integration.db.model.InvoiceFileConfigurationEntity;
+import se.sundsvall.billingpreprocessor.integration.db.model.InvoiceRowEntity;
 
+@SpringBootTest(webEnvironment = MOCK)
+@ActiveProfiles("junit")
 class ExternalSalaryAndPensionInvoiceCreatorTest {
+
+	@MockitoBean
+	private InvoiceFileConfigurationRepository invoiceFileConfigurationRepositoryMock;
+
+	@Autowired
+	private ExternalSalaryAndPensionInvoiceCreator creator;
+
+	@BeforeEach
+	void setup() {
+		final var config = InvoiceFileConfigurationEntity.create()
+			.withEncoding(StandardCharsets.ISO_8859_1.name());
+
+		when(invoiceFileConfigurationRepositoryMock.findByCreatorName("ExternalSalaryAndPensionInvoiceCreator"))
+			.thenReturn(Optional.of(config));
+	}
 
 	@Test
 	void testExternalSalaryAndPensionInvoiceCreator_extendsExternalInvoiceCreator() {
 		assertThat(ExternalSalaryAndPensionInvoiceCreator.class).isAssignableTo(ExternalInvoiceCreator.class);
+	}
+
+	@Test
+	void testCreateFileFooter_withSingleBillingRecord() throws IOException {
+		final var billingRecords = List.of(createBillingRecord(BigDecimal.valueOf(50)));
+
+		final var result = creator.createFileFooter(billingRecords);
+
+		assertThat(new String(result)).isEqualTo("T+00000000005000\n");
+	}
+
+	@Test
+	void testCreateFileFooter_withMultipleBillingRecords() throws IOException {
+		final var billingRecords = List.of(
+			createBillingRecord(BigDecimal.valueOf(100)),
+			createBillingRecord(BigDecimal.valueOf(200), BigDecimal.valueOf(300)));
+
+		final var result = creator.createFileFooter(billingRecords);
+
+		assertThat(new String(result)).isEqualTo("T+00000000060000\n");
+	}
+
+	@Test
+	void testCreateFileFooter_withEmptyList() throws IOException {
+		assertThat(creator.createFileFooter(emptyList())).isEmpty();
+	}
+
+	private BillingRecordEntity createBillingRecord(BigDecimal... amounts) {
+		List<InvoiceRowEntity> invoiceRows = Arrays.stream(amounts)
+			.map(amount -> InvoiceRowEntity.create().withTotalAmount(amount))
+			.toList();
+
+		return BillingRecordEntity.create()
+			.withInvoice(InvoiceEntity.create()
+				.withInvoiceRows(invoiceRows));
 	}
 }

--- a/src/test/java/se/sundsvall/billingpreprocessor/service/creator/InternalInvoiceCreatorTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/service/creator/InternalInvoiceCreatorTest.java
@@ -1,11 +1,13 @@
 package se.sundsvall.billingpreprocessor.service.creator;
 
+import static java.util.Collections.emptyList;
 import static org.apache.commons.text.StringEscapeUtils.unescapeJava;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.zalando.problem.Status.INTERNAL_SERVER_ERROR;
+import static se.sundsvall.billingpreprocessor.Constants.EMPTY_ARRAY;
 import static se.sundsvall.billingpreprocessor.integration.db.model.enums.DescriptionType.DETAILED;
 import static se.sundsvall.billingpreprocessor.integration.db.model.enums.DescriptionType.STANDARD;
 import static se.sundsvall.billingpreprocessor.integration.db.model.enums.Type.INTERNAL;
@@ -134,6 +136,30 @@ class InternalInvoiceCreatorTest {
 		final var expected = getResource("validation/internal_header_expected_format.txt");
 
 		assertThat(new String(result, StandardCharsets.ISO_8859_1)).isEqualTo(expected);
+	}
+
+	@Test
+	void createFileFooterWithEmptyList() throws Exception {
+		final var config = InvoiceFileConfigurationEntity.create().withEncoding(StandardCharsets.ISO_8859_1.name());
+		when(invoiceFileConfigurationRepositoryMock.findByCreatorName("InternalInvoiceCreator")).thenReturn(Optional.of(config));
+
+		final var result = creator.createFileFooter(emptyList());
+
+		assertThat(result).isEqualTo(EMPTY_ARRAY);
+	}
+
+	@Test
+	void createFileFooterWithBillingRecords() throws Exception {
+		final var config = InvoiceFileConfigurationEntity.create().withEncoding(StandardCharsets.ISO_8859_1.name());
+		when(invoiceFileConfigurationRepositoryMock.findByCreatorName("InternalInvoiceCreator")).thenReturn(Optional.of(config));
+
+		final var billingRecords = List.of(
+			createbillingRecordEntity(),
+			createbillingRecordEntity());
+
+		final var result = creator.createFileFooter(billingRecords);
+
+		assertThat(result).isEqualTo(EMPTY_ARRAY);
 	}
 
 	@Test

--- a/src/test/java/se/sundsvall/billingpreprocessor/service/creator/InternalSalaryAndPensionInvoiceCreatorTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/service/creator/InternalSalaryAndPensionInvoiceCreatorTest.java
@@ -1,13 +1,84 @@
 package se.sundsvall.billingpreprocessor.service.creator;
 
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.MOCK;
 
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import se.sundsvall.billingpreprocessor.integration.db.InvoiceFileConfigurationRepository;
+import se.sundsvall.billingpreprocessor.integration.db.model.BillingRecordEntity;
+import se.sundsvall.billingpreprocessor.integration.db.model.InvoiceEntity;
+import se.sundsvall.billingpreprocessor.integration.db.model.InvoiceFileConfigurationEntity;
+import se.sundsvall.billingpreprocessor.integration.db.model.InvoiceRowEntity;
 
+@SpringBootTest(webEnvironment = MOCK)
+@ActiveProfiles("junit")
 class InternalSalaryAndPensionInvoiceCreatorTest {
+
+	@MockitoBean
+	private InvoiceFileConfigurationRepository invoiceFileConfigurationRepositoryMock;
+
+	@Autowired
+	private InternalSalaryAndPensionInvoiceCreator creator;
+
+	@BeforeEach
+	void setup() {
+		final var config = InvoiceFileConfigurationEntity.create()
+			.withEncoding(StandardCharsets.ISO_8859_1.name());
+
+		when(invoiceFileConfigurationRepositoryMock.findByCreatorName("InternalSalaryAndPensionInvoiceCreator"))
+			.thenReturn(Optional.of(config));
+	}
 
 	@Test
 	void testInternalSalaryAndPensionInvoiceCreator_extendsInternalInvoiceCreator() {
 		assertThat(InternalSalaryAndPensionInvoiceCreator.class).isAssignableTo(InternalInvoiceCreator.class);
+	}
+
+	@Test
+	void testCreateFileFooter_withSingleBillingRecord() throws IOException {
+		final var billingRecords = List.of(createBillingRecord(BigDecimal.valueOf(50)));
+
+		final var result = creator.createFileFooter(billingRecords);
+
+		assertThat(new String(result)).isEqualTo("T 50.00          \n");
+	}
+
+	@Test
+	void testCreateFileFooter_withMultipleBillingRecords() throws IOException {
+		final var billingRecords = List.of(
+			createBillingRecord(BigDecimal.valueOf(100)),
+			createBillingRecord(BigDecimal.valueOf(200), BigDecimal.valueOf(300)));
+
+		final var result = creator.createFileFooter(billingRecords);
+
+		assertThat(new String(result)).isEqualTo("T 600.00         \n");
+	}
+
+	@Test
+	void testCreateFileFooter_withEmptyList() throws IOException {
+		assertThat(creator.createFileFooter(emptyList())).isEmpty();
+	}
+
+	private BillingRecordEntity createBillingRecord(BigDecimal... amounts) {
+		List<InvoiceRowEntity> invoiceRows = Arrays.stream(amounts)
+			.map(amount -> InvoiceRowEntity.create().withTotalAmount(amount))
+			.toList();
+
+		return BillingRecordEntity.create()
+			.withInvoice(InvoiceEntity.create()
+				.withInvoiceRows(invoiceRows));
 	}
 }

--- a/src/test/java/se/sundsvall/billingpreprocessor/service/creator/InvoiceCreatorTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/service/creator/InvoiceCreatorTest.java
@@ -1,0 +1,45 @@
+package se.sundsvall.billingpreprocessor.service.creator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static se.sundsvall.billingpreprocessor.Constants.EMPTY_ARRAY;
+
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import se.sundsvall.billingpreprocessor.integration.db.model.BillingRecordEntity;
+import se.sundsvall.billingpreprocessor.integration.db.model.enums.Type;
+
+class InvoiceCreatorTest {
+
+	private static class TestInvoiceCreator implements InvoiceCreator {
+
+		@Override
+		public Type getProcessableType() {
+			return Type.INTERNAL;
+		}
+
+		@Override
+		public String getProcessableCategory() {
+			return "TEST";
+		}
+
+		@Override
+		public byte[] createInvoiceData(BillingRecordEntity billingRecord) throws IOException {
+			return EMPTY_ARRAY;
+		}
+	}
+
+	@Test
+	void defaultCreateFileHeader() throws IOException {
+		final var creator = new TestInvoiceCreator();
+		final var result = creator.createFileHeader();
+		assertThat(result).isEqualTo(EMPTY_ARRAY);
+	}
+
+	@Test
+	void defaultCreateFileFooter() throws IOException {
+		final var creator = new TestInvoiceCreator();
+		final var result = creator.createFileFooter(List.of());
+		assertThat(result).isEqualTo(EMPTY_ARRAY);
+	}
+}

--- a/src/test/java/se/sundsvall/billingpreprocessor/service/creator/config/InvoiceCreatorConfigTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/service/creator/config/InvoiceCreatorConfigTest.java
@@ -45,7 +45,8 @@ class InvoiceCreatorConfigTest {
 				tuple("invoiceRow", "se.sundsvall.billingpreprocessor.service.creator.definition.external.InvoiceRow"),
 				tuple("invoiceDescriptionRow", "se.sundsvall.billingpreprocessor.service.creator.definition.external.InvoiceDescriptionRow"),
 				tuple("invoiceAccountingRow", "se.sundsvall.billingpreprocessor.service.creator.definition.external.InvoiceAccountingRow"),
-				tuple("invoiceFooterRow", "se.sundsvall.billingpreprocessor.service.creator.definition.external.InvoiceFooterRow"));
+				tuple("invoiceFooterRow", "se.sundsvall.billingpreprocessor.service.creator.definition.external.InvoiceFooterRow"),
+				tuple("fileFooterRow", "se.sundsvall.billingpreprocessor.service.creator.definition.external.FileFooterRow"));
 		});
 	}
 
@@ -71,7 +72,8 @@ class InvoiceCreatorConfigTest {
 				tuple("invoiceRowDescriptionRow", "se.sundsvall.billingpreprocessor.service.creator.definition.internal.InvoiceRowDescriptionRow"),
 				tuple("invoiceDescriptionRow", "se.sundsvall.billingpreprocessor.service.creator.definition.internal.InvoiceDescriptionRow"),
 				tuple("invoiceAccountingRow", "se.sundsvall.billingpreprocessor.service.creator.definition.internal.InvoiceAccountingRow"),
-				tuple("invoiceFooterRow", "se.sundsvall.billingpreprocessor.service.creator.definition.internal.InvoiceFooterRow"));
+				tuple("invoiceFooterRow", "se.sundsvall.billingpreprocessor.service.creator.definition.internal.InvoiceFooterRow"),
+				tuple("fileFooterRow", "se.sundsvall.billingpreprocessor.service.creator.definition.internal.FileFooterRow"));
 		});
 	}
 }

--- a/src/test/java/se/sundsvall/billingpreprocessor/service/creator/definition/external/FileFooterRowTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/service/creator/definition/external/FileFooterRowTest.java
@@ -1,0 +1,41 @@
+package se.sundsvall.billingpreprocessor.service.creator.definition.external;
+
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanConstructor;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanEquals;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanHashCode;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanToString;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidGettersAndSetters;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+
+class FileFooterRowTest {
+
+	@Test
+	void testBean() {
+		assertThat(FileFooterRow.class, allOf(
+			hasValidBeanConstructor(),
+			hasValidGettersAndSetters(),
+			hasValidBeanHashCode(),
+			hasValidBeanEquals(),
+			hasValidBeanToString()));
+	}
+
+	@Test
+	void testBuilderMethods() {
+		final var totalAmount = BigDecimal.valueOf(200d);
+
+		final var bean = FileFooterRow.create()
+			.withTotalAmount(totalAmount);
+
+		assertThat(bean.getTotalAmount()).isEqualTo(totalAmount);
+	}
+
+	@Test
+	void testNoDirtOnCreatedBean() {
+		assertThat(FileFooterRow.create()).hasAllNullFieldsOrProperties();
+	}
+}

--- a/src/test/java/se/sundsvall/billingpreprocessor/service/creator/definition/internal/FileFooterRowTest.java
+++ b/src/test/java/se/sundsvall/billingpreprocessor/service/creator/definition/internal/FileFooterRowTest.java
@@ -1,0 +1,41 @@
+package se.sundsvall.billingpreprocessor.service.creator.definition.internal;
+
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanConstructor;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanEquals;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanHashCode;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanToString;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidGettersAndSetters;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+
+class FileFooterRowTest {
+
+	@Test
+	void testBean() {
+		assertThat(FileFooterRow.class, allOf(
+			hasValidBeanConstructor(),
+			hasValidGettersAndSetters(),
+			hasValidBeanHashCode(),
+			hasValidBeanEquals(),
+			hasValidBeanToString()));
+	}
+
+	@Test
+	void testBuilderMethods() {
+		final var totalAmount = BigDecimal.valueOf(200d);
+
+		final var bean = FileFooterRow.create()
+			.withTotalAmount(totalAmount);
+
+		assertThat(bean.getTotalAmount()).isEqualTo(totalAmount);
+	}
+
+	@Test
+	void testNoDirtOnCreatedBean() {
+		assertThat(FileFooterRow.create()).hasAllNullFieldsOrProperties();
+	}
+}

--- a/src/test/resources/api/openapi.yaml
+++ b/src/test/resources/api/openapi.yaml
@@ -5,7 +5,7 @@ info:
   license:
     name: MIT License
     url: https://opensource.org/licenses/MIT
-  version: "5.0"
+  version: "4.0"
 servers:
   - url: http://localhost:55836
     description: Generated server url

--- a/src/test/resources/api/openapi.yaml
+++ b/src/test/resources/api/openapi.yaml
@@ -5,7 +5,7 @@ info:
   license:
     name: MIT License
     url: https://opensource.org/licenses/MIT
-  version: "4.0"
+  version: "5.0"
 servers:
   - url: http://localhost:55836
     description: Generated server url

--- a/src/test/resources/db/scripts/testdata-salaryandpension-it.sql
+++ b/src/test/resources/db/scripts/testdata-salaryandpension-it.sql
@@ -3,46 +3,60 @@
 -- -----------------------------------
 INSERT INTO billing_record (id, category, approved, approved_by, created, modified, status, `type`, municipality_id)
 VALUES	  ('e4ead2ae-daf7-4993-8f64-f9d24417b188', 'SALARY_AND_PENSION', '2025-02-10 13:37:00.000001', 'L&P', '2025-02-09 13:37:00.000001', '2025-02-10 13:37:00.000001', 'APPROVED', 'EXTERNAL', '2281'),
-          ('9d7c72f4-7b18-4a4a-b2ee-4a7007cada3c', 'SALARY_AND_PENSION', '2025-02-10 13:37:00.000001', 'L&P', '2025-02-09 13:37:00.000001', '2025-02-10 13:37:00.000001', 'APPROVED', 'INTERNAL', '2281');
+          ('61b6f794-10c1-4e3b-8a3d-6d789582e5f8', 'SALARY_AND_PENSION', '2025-02-10 13:37:00.000001', 'L&P', '2025-02-09 13:37:00.000001', '2025-02-10 13:37:00.000001', 'APPROVED', 'EXTERNAL', '2281'),
+          ('9d7c72f4-7b18-4a4a-b2ee-4a7007cada3c', 'SALARY_AND_PENSION', '2025-02-10 13:37:00.000001', 'L&P', '2025-02-09 13:37:00.000001', '2025-02-10 13:37:00.000001', 'APPROVED', 'INTERNAL', '2281'),
+          ('8fe12401-ea81-cdfe-a239-76febb3101dd', 'SALARY_AND_PENSION', '2025-02-10 13:37:00.000001', 'L&P', '2025-02-09 13:37:00.000001', '2025-02-10 13:37:00.000001', 'APPROVED', 'INTERNAL', '2281');
 
 -- -----------------------------------
 -- Invoices
 -- -----------------------------------
 INSERT INTO invoice (id, customer_id, customer_reference, description, `date`, due_date, our_reference, total_amount)
 VALUES	  ('e4ead2ae-daf7-4993-8f64-f9d24417b188', 'Seaview Middle School', 'PRI22LUG', 'Extra löneutbetalning - Systemet', NULL, NULL, 'Hanna Montana',  376.38),
-          ('9d7c72f4-7b18-4a4a-b2ee-4a7007cada3c', '10', 'HAN99MON', 'Extra löneutbetalning - Direktinsättning', NULL, NULL, 'Lola Luftnagle', 1530.0);
+          ('61b6f794-10c1-4e3b-8a3d-6d789582e5f8', 'Acme Corporation', 'BOB99', 'Utvecklingskostnad 2%', NULL, NULL, 'Lola Macarola',  490.00),
+          ('9d7c72f4-7b18-4a4a-b2ee-4a7007cada3c', '10', 'HAN99MON', 'Extra löneutbetalning - Direktinsättning', NULL, NULL, 'Lola Luftnagle', 1530.0),
+          ('8fe12401-ea81-cdfe-a239-76febb3101dd', '20', 'ZXZ99YXY', 'Extra löneutbetalning - Direktinsättning', NULL, NULL, 'John Doe', 306.0);
 
 -- -----------------------------------
 -- Invoice rows
 -- -----------------------------------
 INSERT INTO invoice_row (id, cost_per_unit, quantity, total_amount, vat_code, invoice_id)
 VALUES	  (100, 306.0,  1.23, 376.38, '25', 'e4ead2ae-daf7-4993-8f64-f9d24417b188'),
+          (101, 245.0,  2.00, 490.00, '25', '61b6f794-10c1-4e3b-8a3d-6d789582e5f8'),
           (200, 1500.0, 1.00, 1500.0, NULL, '9d7c72f4-7b18-4a4a-b2ee-4a7007cada3c'),
-          (201, 30.0, 1.00, 30.0, NULL, '9d7c72f4-7b18-4a4a-b2ee-4a7007cada3c');
+          (201, 30.0, 1.00, 30.0, NULL, '9d7c72f4-7b18-4a4a-b2ee-4a7007cada3c'),
+          (300, 300.0, 1.00, 300.0, NULL, '8fe12401-ea81-cdfe-a239-76febb3101dd'),
+          (301, 6.0, 1.00, 6.0, NULL, '8fe12401-ea81-cdfe-a239-76febb3101dd');
 
 -- -----------------------------------
 -- Account information
 -- -----------------------------------
 INSERT INTO account_information (invoice_row_id, accural_key, activity, cost_center, counter_part, department, article, project, subaccount, amount)
 VALUES	  (100, NULL, '5757', '15800234', '510', '920360', NULL, NULL, '363000', 369.0),
-          (100, NULL, '5757', '15800234', '510', '920360', NULL, '11041', '363000', 7.38),
+          (101, NULL, '5757', '15800234', '510', '920360', NULL, '11041', '363000', 7.38),
           (200, NULL, '5756', '15810100', '110', '920360', NULL, NULL, '936300', 1500.0),
-          (201, NULL, '5756', '15810100', '110', '920360', NULL, NULL, '936300', 30.0);
+          (201, NULL, '5756', '15810100', '110', '920360', NULL, NULL, '936300', 30.0),
+          (300, NULL, '5756', '15810100', '110', '920360', NULL, NULL, '936300', 300.0),
+          (301, NULL, '5756', '15810100', '110', '920360', NULL, NULL, '936300', 6.0);
 
 -- -----------------------------------
 -- Descriptions
 -- -----------------------------------
 INSERT INTO description (text, `type`, invoice_row_id)
 VALUES	  ('Ärendenummer: LoP-25020125', 'STANDARD', 100),
+          ('Utvecklingskostnad 2%', 'STANDARD', 101),
           ('Ärendenummer: LoP-25020123', 'STANDARD', 200),
-          ('Utvecklingskostnad 2%', 'STANDARD', 201);
+          ('Utvecklingskostnad 2%', 'STANDARD', 201),
+          ('Ärendenummer: LoP-21235020', 'STANDARD', 300),
+          ('Utvecklingskostnad 2%', 'STANDARD', 301);
 
 -- -----------------------------------
 -- Recipients
 -- -----------------------------------
 INSERT INTO recipient (id, care_of, city, street, postal_code, first_name, last_name, organization_name, party_id, user_id)
 VALUES	  ('e4ead2ae-daf7-4993-8f64-f9d24417b188', NULL, 'HANZALAND', 'MIDDLE SCHOOL STREET 123', '90102', NULL, NULL, 'Seaview Middle School', 'ac653c32-b26c-47e8-8c3d-4d18c1b5111c', NULL),
-          ('9d7c72f4-7b18-4a4a-b2ee-4a7007cada3c', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+          ('61b6f794-10c1-4e3b-8a3d-6d789582e5f8', NULL, 'FOOTOWN', 'FOO BAR BAZ 860', '42012', NULL, NULL, 'Acme Corporation', 'ac653c32-b26c-47e8-8c3d-4d18c1b5111c', NULL),
+          ('9d7c72f4-7b18-4a4a-b2ee-4a7007cada3c', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+          ('8fe12401-ea81-cdfe-a239-76febb3101dd', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 -------------------------------------
 -- Extra parameters
@@ -52,6 +66,12 @@ VALUES
     ('e4ead2ae-daf7-4993-8f64-f9d24417b188', 'errandId', 'fb19ecf5-a7c2-465e-22ac-c7ea9b4f1c15'),
     ('e4ead2ae-daf7-4993-8f64-f9d24417b188', 'errandNumber', 'LoP-25020125'),
     ('e4ead2ae-daf7-4993-8f64-f9d24417b188', 'referenceName', 'Principal Luger'),
+    ('61b6f794-10c1-4e3b-8a3d-6d789582e5f8', 'errandId', 'fb19ecf5-a7c2-465e-22ac-c7ea9b4f1c15'),
+    ('61b6f794-10c1-4e3b-8a3d-6d789582e5f8', 'errandNumber', 'LoP-25020125'),
+    ('61b6f794-10c1-4e3b-8a3d-6d789582e5f8', 'referenceName', 'HR Rep. Bob'),
     ('9d7c72f4-7b18-4a4a-b2ee-4a7007cada3c', 'errandId', 'cd25a29e-3e58-4fbd-979a-ece33b528d12'),
     ('9d7c72f4-7b18-4a4a-b2ee-4a7007cada3c', 'errandNumber', 'LoP-25020123'),
-    ('9d7c72f4-7b18-4a4a-b2ee-4a7007cada3c', 'referenceName', 'Hanna Montana');
+    ('9d7c72f4-7b18-4a4a-b2ee-4a7007cada3c', 'referenceName', 'Hanna Montana'),
+    ('8fe12401-ea81-cdfe-a239-76febb3101dd', 'errandId', 'cd25a29e-3e58-4fbd-979a-ece33b528d12'),
+    ('8fe12401-ea81-cdfe-a239-76febb3101dd', 'errandNumber', 'LoP-21235020'),
+    ('8fe12401-ea81-cdfe-a239-76febb3101dd', 'referenceName', 'Lola Macarola');


### PR DESCRIPTION
Add file footer row with total amount for all billing records included in the file instead of one entry for each billing. This applies to the category `SALARY_AND_PENSION` and both `INTERNAL` or `EXTERNAL` invoices types.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [x] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [x] Yes (I have stepped the version number accordingly)
- [ ] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
